### PR TITLE
Adding DAE equation types and constraints.

### DIFF
--- a/integrators/dae_integrator.h
+++ b/integrators/dae_integrator.h
@@ -20,6 +20,44 @@ typedef enum
   DAE_DIFFERENTIAL
 } dae_equation_t;
 
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations are algebraic.
+extern dae_equation_t* DAE_ALL_ALGEBRAIC;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations are differential.
+extern dae_equation_t* DAE_ALL_DIFFERENTIAL;
+
+// This type indicates constraints (if any) on equations in a DAE system.
+typedef enum
+{
+  DAE_UNCONSTRAINED,
+  DAE_NEGATIVE,
+  DAE_NONPOSITIVE,
+  DAE_NONNEGATIVE,
+  DAE_POSITIVE
+} dae_constraint_t;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// no equations have constraints.
+extern dae_constraint_t* DAE_ALL_UNCONSTRAINED;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations have solution values that are negative.
+extern dae_constraint_t* DAE_ALL_NEGATIVE;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations have solution values that are non-positive.
+extern dae_constraint_t* DAE_ALL_NONPOSITIVE;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations have solution values that are non-negative.
+extern dae_constraint_t* DAE_ALL_NONNEGATIVE;
+
+// This can be passed as an argument to dae_integrator_new to indicate that 
+// all equations have solution values that are positive.
+extern dae_constraint_t* DAE_ALL_POSITIVE;
+
 // Types of Krylov solver to use for our DAE method.
 typedef enum 
 {
@@ -50,14 +88,6 @@ typedef struct
   // for a fatal error.
   dae_integrator_residual_func residual;
 
-  // This (optional) function sets the contraints vector, which places algebraic 
-  // constraints on the components of the solution vector x. If constraints[i] is:
-  // 0.0  - no constraint is placed on x[i].
-  // 1.0  - x[i] must be non-negative.
-  // -1.0 - x[i] must be non-positive.
-  // 2.0  - x[i] must be positive.
-  dae_integrator_constraints_func set_constraints;
-
   // This (optional) function destroys the state (context) when the time integrator 
   // is destroyed.
   dae_integrator_dtor dtor;
@@ -72,10 +102,15 @@ typedef struct dae_integrator_t dae_integrator_t;
 // Differential Algebraic Equations (DAE) with a given maximum subspace 
 // dimension of max_krylov_dim. The equation_types array (of length num_local_values)
 // indicates whether each equation in the system is algebraic (DAE_ALGEBRAIC) 
-// or differential (DAE_DIFFERENTIAL).
+// or differential (DAE_DIFFERENTIAL). The constraints array indicates any 
+// constraints on the solution for a given component (DAE_UNCONSTRAINED, 
+// DAE_NEGATIVE, DAE_NONPOSITIVE, DAE_NONNEGATIVE, DAE_POSITIVE). See the 
+// DAE_ALL* symbols above for shorthand ways of expressing systems with 
+// simple equation types and constraints.
 dae_integrator_t* dae_integrator_new(int order,
                                      MPI_Comm comm,
                                      dae_equation_t* equation_types,
+                                     dae_constraint_t* constraints,
                                      int num_local_values,
                                      int num_remote_values,
                                      void* context,

--- a/integrators/dae_integrator.h
+++ b/integrators/dae_integrator.h
@@ -12,6 +12,14 @@
 #include "core/adj_graph.h"
 #include "integrators/newton_pc.h"
 
+// This type indicates whether a given equation in a DAE system is 
+// algebraic or differential.
+typedef enum
+{
+  DAE_ALGEBRAIC,
+  DAE_DIFFERENTIAL
+} dae_equation_t;
+
 // Types of Krylov solver to use for our DAE method.
 typedef enum 
 {
@@ -62,9 +70,12 @@ typedef struct dae_integrator_t dae_integrator_t;
 
 // Creates an integrator that uses a Newton-Krylov method to solve a system of 
 // Differential Algebraic Equations (DAE) with a given maximum subspace 
-// dimension of max_krylov_dim. 
+// dimension of max_krylov_dim. The equation_types array (of length num_local_values)
+// indicates whether each equation in the system is algebraic (DAE_ALGEBRAIC) 
+// or differential (DAE_DIFFERENTIAL).
 dae_integrator_t* dae_integrator_new(int order,
                                      MPI_Comm comm,
+                                     dae_equation_t* equation_types,
                                      int num_local_values,
                                      int num_remote_values,
                                      void* context,

--- a/integrators/tests/heat2d_integrator.c
+++ b/integrators/tests/heat2d_integrator.c
@@ -119,13 +119,6 @@ static int heat2d_res(void* context, real_t t, real_t* u, real_t* u_dot, real_t*
   return 0;
 }
 
-static void heat2d_set_constraints(void* context, real_t* constraints)
-{
-  // All solution values are non-negative.
-  for (int i = 0; i < NEQ; ++i)
-    constraints[i] = 1.0;
-}
-
 void heat2d_set_initial_conditions(dae_integrator_t* integ, real_t** u, real_t** u_dot)
 {
   heat2d_t* data = dae_integrator_context(integ);
@@ -180,13 +173,12 @@ static dae_integrator_t* heat2d_integrator_new(heat2d_t* data, newton_pc_t* prec
   // Set up a time integrator using GMRES with a Krylov space of maximum 
   // dimension 5.
   dae_integrator_vtable vtable = {.residual = heat2d_res,
-                                  .set_constraints = heat2d_set_constraints,
                                   .dtor = heat2d_dtor};
   // This is really a purely differential system.                                 
-  dae_equation_t eqn_types[NEQ];
-  for (int i = 0; i < NEQ; ++i)
-    eqn_types[i] = DAE_DIFFERENTIAL;
-  dae_integrator_t* integ = dae_integrator_new(5, MPI_COMM_SELF, eqn_types, NEQ, 0, data, vtable, 
+  dae_integrator_t* integ = dae_integrator_new(5, MPI_COMM_SELF, 
+                                               DAE_ALL_DIFFERENTIAL, 
+                                               DAE_ALL_NONNEGATIVE,
+                                               NEQ, 0, data, vtable, 
                                                precond, DAE_GMRES, 5);
 
   return integ;

--- a/integrators/tests/heat2d_integrator.c
+++ b/integrators/tests/heat2d_integrator.c
@@ -182,7 +182,11 @@ static dae_integrator_t* heat2d_integrator_new(heat2d_t* data, newton_pc_t* prec
   dae_integrator_vtable vtable = {.residual = heat2d_res,
                                   .set_constraints = heat2d_set_constraints,
                                   .dtor = heat2d_dtor};
-  dae_integrator_t* integ = dae_integrator_new(5, MPI_COMM_SELF, NEQ, 0, data, vtable, 
+  // This is really a purely differential system.                                 
+  dae_equation_t eqn_types[NEQ];
+  for (int i = 0; i < NEQ; ++i)
+    eqn_types[i] = DAE_DIFFERENTIAL;
+  dae_integrator_t* integ = dae_integrator_new(5, MPI_COMM_SELF, eqn_types, NEQ, 0, data, vtable, 
                                                precond, DAE_GMRES, 5);
 
   return integ;


### PR DESCRIPTION
Knowing whether a system is algebraic, differential, or a mix allows us to take advantage of more mathematical structure. Similarly, applying constraints on the positivity (etc) of a solution component can help us avoid strange nonphysical shenanigans.