### PR TITLE
Bugfix for stopping all timers.

### DIFF
--- a/core/timer.c
+++ b/core/timer.c
@@ -174,6 +174,7 @@ void polymec_timer_stop_all()
   {
     while ((current_timer != NULL) && (current_timer != all_timers->data[0]))
       polymec_timer_stop(current_timer);
+    polymec_timer_stop(current_timer); // Last one!
   }
 }
 


### PR DESCRIPTION
Previously the top-level ("polymec") timer was not stopped by polymec_timer_stop_all(), producing erroneous statistics in timer reports.