### PR TITLE
Added single-rank constructors for rectilinear/uniform meshes.

### DIFF
--- a/geometry/create_rectilinear_mesh.c
+++ b/geometry/create_rectilinear_mesh.c
@@ -356,6 +356,34 @@ mesh_t* create_rectilinear_mesh(MPI_Comm comm,
   return mesh;
 }
 
+mesh_t* create_rectilinear_mesh_on_rank(MPI_Comm comm,
+                                        int rank,
+                                        real_t* xs, int nxs, 
+                                        real_t* ys, int nys, 
+                                        real_t* zs, int nzs)
+{
+  ASSERT(comm != MPI_COMM_SELF);
+  ASSERT(rank >= 0);
+
+  int my_rank, nprocs;
+  MPI_Comm_rank(comm, &my_rank);
+  MPI_Comm_rank(comm, &nprocs);
+
+  if (rank > nprocs)
+    polymec_error("create_rectilinear_mesh_on_rank: invalid rank: %d", rank);
+
+  mesh_t* mesh = NULL;
+  if (my_rank == rank)
+    mesh = create_rectilinear_mesh(comm, xs, nxs, ys, nys, zs, nzs);
+  else
+  {
+    // Initialize serializers.
+    serializer_t* s = cubic_lattice_serializer();
+    s = bbox_serializer();
+  }
+  return mesh;
+}
+
 void tag_rectilinear_mesh_faces(mesh_t* mesh, 
                                 const char* x1_tag, 
                                 const char* x2_tag, 

--- a/geometry/create_rectilinear_mesh.h
+++ b/geometry/create_rectilinear_mesh.h
@@ -19,6 +19,17 @@ mesh_t* create_rectilinear_mesh(MPI_Comm comm,
                                 real_t* ys, int nys, 
                                 real_t* zs, int nzs);
 
+// This function creates and returns a rectilinear mesh whose nodes are 
+// given by the xs, ys, and zs arrays on the given communicator 
+// ONLY ON THE GIVEN RANK. The function returns the mesh on that rank and 
+// a NULL pointer on all other ranks. MPI_COMM_SELF cannot be used as the 
+// communicator.
+mesh_t* create_rectilinear_mesh_on_rank(MPI_Comm comm,
+                                        int rank,
+                                        real_t* xs, int nxs, 
+                                        real_t* ys, int nys, 
+                                        real_t* zs, int nzs);
+
 // This function tags the faces of a rectilinear mesh for convenient boundary 
 // condition assignments. This also creates a property named 
 // "rectilinear_boundary_tags" containing an array of 6 strings:

--- a/geometry/create_uniform_mesh.c
+++ b/geometry/create_uniform_mesh.c
@@ -47,3 +47,27 @@ mesh_t* create_uniform_mesh(MPI_Comm comm, int nx, int ny, int nz, bbox_t* bbox)
   return mesh;
 }
 
+mesh_t* create_uniform_mesh_on_rank(MPI_Comm comm, int rank,
+                                    int nx, int ny, int nz, bbox_t* bbox)
+{
+  ASSERT(comm != MPI_COMM_SELF);
+  ASSERT(rank >= 0);
+
+  int my_rank, nprocs;
+  MPI_Comm_rank(comm, &my_rank);
+  MPI_Comm_rank(comm, &nprocs);
+
+  if (rank > nprocs)
+    polymec_error("create_uniform_mesh_on_rank: invalid rank: %d", rank);
+
+  mesh_t* mesh = NULL;
+  if (my_rank == rank)
+    mesh = create_uniform_mesh(comm, nx, ny, nz, bbox);
+  else
+  {
+    // Initialize serializers.
+    serializer_t* s = cubic_lattice_serializer();
+    s = bbox_serializer();
+  }
+  return mesh;
+}

--- a/geometry/create_uniform_mesh.h
+++ b/geometry/create_uniform_mesh.h
@@ -16,5 +16,11 @@
 // The mesh spans the rectangular region of space defined by the bounding box.
 mesh_t* create_uniform_mesh(MPI_Comm comm, int nx, int ny, int nz, bbox_t* bbox);
 
+// This function creates and returns a uniform mesh of nx x ny x nz cells
+// on the given communicator ONLY ON THE GIVEN RANK. The function returns the 
+// mesh on that rank and a NULL pointer on all other ranks. MPI_COMM_SELF 
+// cannot be used as the communicator.
+mesh_t* create_uniform_mesh_on_rank(MPI_Comm comm, int rank,
+                                    int nx, int ny, int nz, bbox_t* bbox);
 #endif
 


### PR DESCRIPTION
To enhance the degree to which we execute the same instructions on all ranks, I've added:

* create_rectilinear_mesh_on_rank
* create_uniform_mesh_on_rank

These are only really needed because repartition_mesh doesn't work yet.