### PR TITLE
Successfully set up upload of Travis CI artifacts to Amazon S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,11 @@ addons:
     # We stick build artifacts onto Amazon S3 so that they can be retrieved 
     # either for deployment or for testing other polymec-based libs.
     paths:
-      - $(find $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI | tr "\n" ":")
+      - $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz
 
   s3_region: "us-west-2"
+
+after_success: cd $HOME; tar czvf polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz polymec-$CC-debug=$DEBUG-mpi=$MPI/* 
 
 script: 
   - make config debug=$DEBUG mpi=$MPI prefix=$HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI && make -j4 debug=$DEBUG mpi=$MPI install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
     paths:
       - $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz
 
-  s3_region: "us-west-2"
+    s3_region: us-west-2
 
 after_success: cd $HOME; tar czvf polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz polymec-$CC-debug=$DEBUG-mpi=$MPI/* 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
 
     s3_region: us-west-2
 
-    debug: true
+    #debug: true
 
 after_success: cd $HOME; tar czvf polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz polymec-$CC-debug=$DEBUG-mpi=$MPI/* 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ addons:
       - libopenmpi-dev
       - gfortran
 
+  artifacts:
+    # We stick build artifacts onto Amazon S3 so that they can be retrieved 
+    # either for deployment or for testing other polymec-based libs.
+    paths:
+      - $(find polymec | tr "\n" ":")
+
+  s3_region: "us-west-2"
+
 script: 
-  - make config debug=$DEBUG mpi=$MPI && make -j4 debug=$DEBUG mpi=$MPI 
+  - make config debug=$DEBUG mpi=$MPI prefix=polymec && make -j4 debug=$DEBUG mpi=$MPI install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ addons:
     paths:
       - $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz
 
+    s3_region: us-west-2
+
     debug: true
 
 after_success: cd $HOME; tar czvf polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz polymec-$CC-debug=$DEBUG-mpi=$MPI/* 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ addons:
     # We stick build artifacts onto Amazon S3 so that they can be retrieved 
     # either for deployment or for testing other polymec-based libs.
     paths:
-      - $(find polymec | tr "\n" ":")
+      - $(find $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI | tr "\n" ":")
 
   s3_region: "us-west-2"
 
 script: 
-  - make config debug=$DEBUG mpi=$MPI prefix=polymec && make -j4 debug=$DEBUG mpi=$MPI install
+  - make config debug=$DEBUG mpi=$MPI prefix=$HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI && make -j4 debug=$DEBUG mpi=$MPI install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
     paths:
       - $HOME/polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz
 
-    s3_region: us-west-2
+    debug: true
 
 after_success: cd $HOME; tar czvf polymec-$CC-debug=$DEBUG-mpi=$MPI.tar.gz polymec-$CC-debug=$DEBUG-mpi=$MPI/* 
 


### PR DESCRIPTION
Polymec build artifacts from Travis CI are now uploaded and made available for other polymec-based libraries for their own continuous integration.