### PR TITLE
Fixes for thread_pool and krylov_solver

### DIFF
--- a/core/polymec.h.in
+++ b/core/polymec.h.in
@@ -60,6 +60,7 @@
 #define POLYMEC_HAVE_DOUBLE_PRECISION @HAVE_DOUBLE_PRECISION@
 #define POLYMEC_PRECISION @POLYMEC_PRECISION@
 #define MPI_REAL_T @POLYMEC_MPI_REAL_TYPE@
+#define SHARED_LIBRARY_SUFFIX "@CMAKE_SHARED_LIBRARY_SUFFIX@"
 
 // In defining real_t, we have to accommodate Metis, which defines 
 // its own.

--- a/core/tests/test_thread_pool.c
+++ b/core/tests/test_thread_pool.c
@@ -36,8 +36,8 @@ static void crunch_numbers(void* context)
 static void do_number_crunching_test(void** state, thread_pool_t* pool)
 {
   int num_numbers = 20;
-  global_array = malloc(sizeof(double) * 20);
-  global_indices = malloc(sizeof(int) * 20);
+  global_array = malloc(sizeof(double) * num_numbers);
+  global_indices = malloc(sizeof(int) * num_numbers);
   for (int i = 0; i < num_numbers; ++i)
   {
     global_indices[i] = i;
@@ -55,9 +55,12 @@ static void do_number_crunching_test(void** state, thread_pool_t* pool)
 
 void test_number_crunching(void** state)
 {
-  thread_pool_t* pool = thread_pool_new();
-  do_number_crunching_test(state, pool);
-  thread_pool_free(pool);
+  for (int iter = 0; iter < 1000; ++iter)
+  {
+    thread_pool_t* pool = thread_pool_new();
+    do_number_crunching_test(state, pool);
+    thread_pool_free(pool);
+  }
 }
 
 void test_N_executions(void** state, int N)
@@ -71,8 +74,11 @@ void test_N_executions(void** state, int N)
 
 void test_several_executions(void** state)
 {
-  for (int N = 2; N <= 10; ++N)
-    test_N_executions(state, N);
+  for (int iter = 0; iter < 100; ++iter)
+  {
+    for (int N = 2; N <= 10; ++N)
+      test_N_executions(state, N);
+  }
 }
 
 int main(int argc, char* argv[]) 


### PR DESCRIPTION
* Fixed a bug in thread_pool that was preventing threads from finishing their tasks before thread_pool_execute() returned.
* SHARED_LIBRARY_SUFFIX is now passed to the build system, contains ".so", ".dylib", ".dll (etc)
* krylov_solver tests now are skipped if PETSc is not found as a shared library.

Fixes #65 