### PR TITLE
Some low-level parallel exchange enhancements and pre-v1.0 cleanup

### DIFF
--- a/core/adj_graph.c
+++ b/core/adj_graph.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/adj_graph.h
+++ b/core/adj_graph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/allocators.c
+++ b/core/allocators.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/allocators.h
+++ b/core/allocators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/arch.c
+++ b/core/arch.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/arch.h
+++ b/core/arch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/array.h
+++ b/core/array.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/array_utils.c
+++ b/core/array_utils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/array_utils.h
+++ b/core/array_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/avl_tree.h
+++ b/core/avl_tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/block_diagonal_matrix.c
+++ b/core/block_diagonal_matrix.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/block_diagonal_matrix.h
+++ b/core/block_diagonal_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/comparators.h
+++ b/core/comparators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/declare_nd_array.h
+++ b/core/declare_nd_array.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/dense_local_matrix.c
+++ b/core/dense_local_matrix.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/dense_local_matrix.h
+++ b/core/dense_local_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/dlist.h
+++ b/core/dlist.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/exchanger.c
+++ b/core/exchanger.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/exchanger.h
+++ b/core/exchanger.h
@@ -166,4 +166,73 @@ exchanger_t* create_migrator(MPI_Comm comm,
                              int64_t* local_partition,
                              int num_vertices);
 
+//------------------------------------------------------------------------
+//                      Exchanging parallel metadata
+//------------------------------------------------------------------------
+// It is often expedient to send metadata between communicating processes
+// instead of performing an exchange on full data arrays. The following 
+// methods allow the transfer of metadata from a set of "send arrays" 
+// to a set of "receive arrays", based on the topology established within 
+// the given exchanger.
+//------------------------------------------------------------------------
+
+// Create a set of arrays to use in sending metadata of the given type. This 
+// allocates and returns a set of exchanger_num_sends(ex) arrays, each sized 
+// and indexed appropriately for sending metadata with the given stride using 
+// the given exchanger.
+void** exchanger_create_metadata_send_arrays(exchanger_t* ex,
+                                             MPI_Datatype type,
+                                             int stride);
+
+// Frees the storage associated with the metadata send arrays created with 
+// exchanger_create_metadata_send_arrays.
+void exchanger_free_metadata_send_arrays(exchanger_t* ex,
+                                         void** arrays);
+
+// Create a set of arrays to use for receiving metadata of the given type. 
+// This allocates and returns a set of exchanger_num_receives(ex) arrays, each 
+// sized and indexed appropriately for receiving metadata with the given stride 
+// using the given exchanger.
+void** exchanger_create_metadata_receive_arrays(exchanger_t* ex,
+                                                MPI_Datatype type,
+                                                int stride);
+
+// Frees the storage associated with the metadata receive arrays created with 
+// exchanger_create_metadata_receive_arrays.
+void exchanger_free_metadata_receive_arrays(exchanger_t* ex,
+                                            void** arrays);
+ 
+// This enumerated type indicates the direction of metadata transfer. 
+// EX_METADATA_FORWARD indicates a "forward" transfer (from sends to receives), 
+// while EX_METADATA_REVERSE indicates a "reverse" transer (from receives to sends).
+typedef enum
+{
+  EX_METADATA_FORWARD,
+  EX_METADATA_REVERSE
+} exchanger_metadata_dir;
+
+// Performs a transfer of metadata of the given type, with the given stride, 
+// in the given direction.
+void exchanger_transfer_metadata(exchanger_t* ex,
+                                 void** send_arrays,
+                                 void** receive_arrays,
+                                 int stride,
+                                 int tag,
+                                 MPI_Datatype type,
+                                 exchanger_metadata_dir direction);
+
+// Starts an asyncronous transfer of metadata, returning a token that can be used 
+// to finish it.
+int exchanger_start_metadata_transfer(exchanger_t* ex,
+                                      void** send_arrays,
+                                      void** receive_arrays,
+                                      int stride,
+                                      int tag,
+                                      MPI_Datatype type,
+                                      exchanger_metadata_dir direction);
+
+// Finishes the asyncronous metadata transfer associated with the given token.
+void exchanger_finish_metadata_transfer(exchanger_t* ex,
+                                        int token);
+
 #endif

--- a/core/exchanger.h
+++ b/core/exchanger.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/file_utils.c
+++ b/core/file_utils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/file_utils.h
+++ b/core/file_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/hash_functions.h
+++ b/core/hash_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/heap.h
+++ b/core/heap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/hilbert.c
+++ b/core/hilbert.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/hilbert.h
+++ b/core/hilbert.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/index_space.c
+++ b/core/index_space.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/index_space.h
+++ b/core/index_space.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/interpreter.c
+++ b/core/interpreter.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/interpreter.h
+++ b/core/interpreter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/interpreter_register_default_functions.c
+++ b/core/interpreter_register_default_functions.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/kd_tree.c
+++ b/core/kd_tree.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/kd_tree.h
+++ b/core/kd_tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/key_value.h
+++ b/core/key_value.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/krylov_solver.c
+++ b/core/krylov_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/krylov_solver.h
+++ b/core/krylov_solver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/least_squares.c
+++ b/core/least_squares.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/least_squares.h
+++ b/core/least_squares.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/linear_algebra.c
+++ b/core/linear_algebra.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/linear_algebra.h
+++ b/core/linear_algebra.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/local_matrix.c
+++ b/core/local_matrix.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/local_matrix.h
+++ b/core/local_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/logging.c
+++ b/core/logging.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/logging.h
+++ b/core/logging.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/memory_info.c
+++ b/core/memory_info.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/memory_info.h
+++ b/core/memory_info.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/mesh.c
+++ b/core/mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/mesh.h
+++ b/core/mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/mesh_node_exchangers.c
+++ b/core/mesh_node_exchangers.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/newton.c
+++ b/core/newton.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/newton.h
+++ b/core/newton.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/norms.h
+++ b/core/norms.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/octree.c
+++ b/core/octree.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/octree.h
+++ b/core/octree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/options.c
+++ b/core/options.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/options.h
+++ b/core/options.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/ordered_map.h
+++ b/core/ordered_map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/ordered_set.h
+++ b/core/ordered_set.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/parallel_qsort.c
+++ b/core/parallel_qsort.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/parallel_qsort.h
+++ b/core/parallel_qsort.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/partition_mesh.c
+++ b/core/partition_mesh.c
@@ -1370,6 +1370,8 @@ exchanger_t* distribute_mesh(mesh_t** mesh, MPI_Comm comm, int64_t* global_parti
 
 exchanger_t* repartition_mesh(mesh_t** mesh, int* weights, real_t imbalance_tol)
 {
+  POLYMEC_NOT_IMPLEMENTED;
+
   ASSERT(imbalance_tol > 0.0);
   ASSERT(imbalance_tol <= 1.0);
   mesh_t* m = *mesh;
@@ -1385,8 +1387,6 @@ exchanger_t* repartition_mesh(mesh_t** mesh, int* weights, real_t imbalance_tol)
   // On a single process, repartitioning has no meaning.
   if (nprocs == 1)
     return exchanger_new(m->comm);
-
-  POLYMEC_NOT_IMPLEMENTED;
 
   // Generate a local adjacency graph for the mesh.
   adj_graph_t* local_graph = graph_from_mesh_cells(m);

--- a/core/partition_mesh.c
+++ b/core/partition_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/partition_mesh.h
+++ b/core/partition_mesh.h
@@ -25,6 +25,7 @@ exchanger_t* partition_mesh(mesh_t** mesh, MPI_Comm comm, int* weights, real_t i
 // and returns an exchanger object that can be used to migrate data from the 
 // old partition to the new. The mesh is consumed and replaced with a 
 // repartitioned mesh.
+// NOTE: This is not currently implemented.
 exchanger_t* repartition_mesh(mesh_t** mesh, int* weights, real_t imbalance_tol);
 
 // While partition_mesh and repartition_mesh are all-in-one mesh partitioners, the 

--- a/core/partition_mesh.h
+++ b/core/partition_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/partition_point_cloud.c
+++ b/core/partition_point_cloud.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/partition_point_cloud.h
+++ b/core/partition_point_cloud.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/permutations.c
+++ b/core/permutations.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/permutations.h
+++ b/core/permutations.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/petsc_krylov_solver.c
+++ b/core/petsc_krylov_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point.c
+++ b/core/point.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point.h
+++ b/core/point.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point2.c
+++ b/core/point2.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point2.h
+++ b/core/point2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point_cloud.c
+++ b/core/point_cloud.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/point_cloud.h
+++ b/core/point_cloud.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/polymec.c
+++ b/core/polymec.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/polynomial.c
+++ b/core/polynomial.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/polynomial.h
+++ b/core/polynomial.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/priority_queue.h
+++ b/core/priority_queue.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/rng.c
+++ b/core/rng.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/rng.h
+++ b/core/rng.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/serializer.c
+++ b/core/serializer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/serializer.h
+++ b/core/serializer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/silo_file.c
+++ b/core/silo_file.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/silo_file.h
+++ b/core/silo_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/slist.h
+++ b/core/slist.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/sp_func.c
+++ b/core/sp_func.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/sp_func.h
+++ b/core/sp_func.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/sparse_local_matrix.c
+++ b/core/sparse_local_matrix.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/sparse_local_matrix.h
+++ b/core/sparse_local_matrix.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/special_functions.c
+++ b/core/special_functions.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/special_functions.h
+++ b/core/special_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/st_func.c
+++ b/core/st_func.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/st_func.h
+++ b/core/st_func.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/string_utils.c
+++ b/core/string_utils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/string_utils.h
+++ b/core/string_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/sundials_helpers.h
+++ b/core/sundials_helpers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/table.h
+++ b/core/table.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tagger.c
+++ b/core/tagger.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tagger.h
+++ b/core/tagger.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -30,18 +30,15 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 add_mpi_polymec_test(test_parallel_kd_tree test_kd_tree.c 1 2 3 4)
-#add_mpi_polymec_test(test_parallel_qsort test_parallel_qsort.c 1 2 3 4)
 add_mpi_polymec_test(test_exchanger test_exchanger.c 1 2 3 4)
 add_mpi_polymec_test(test_mesh_node_exchangers test_mesh_node_exchangers.c ../../geometry/create_uniform_mesh.c ../../geometry/create_rectilinear_mesh.c ../../geometry/cubic_lattice.c 1 2 3 4)
 add_mpi_polymec_test(test_partition_mesh test_partition_mesh.c ../../geometry/create_uniform_mesh.c ../../geometry/create_rectilinear_mesh.c ../../geometry/cubic_lattice.c 1 2 3 4)
-add_mpi_polymec_test(test_repartition_mesh test_repartition_mesh.c ../../geometry/create_uniform_mesh.c ../../geometry/create_rectilinear_mesh.c ../../geometry/cubic_lattice.c 1 2)# 3 4)
 add_mpi_polymec_test(test_partition_point_cloud test_partition_point_cloud.c ../../geometry/create_point_lattice.c ../../geometry/cubic_lattice.c 1 2 3 4)
-#add_mpi_polymec_test(test_repartition_point_cloud test_repartition_point_cloud.c 1 2 3 4)
 
-# The following tests are currently expected to fail.
-if (HAVE_MPI EQUAL 1)
-  set(failing_tests test_repartition_mesh_2_proc)
-endif()
+# Tests for features we will add later.
+#add_mpi_polymec_test(test_parallel_qsort test_parallel_qsort.c 1 2 3 4)
+#add_mpi_polymec_test(test_repartition_mesh test_repartition_mesh.c ../../geometry/create_uniform_mesh.c ../../geometry/create_rectilinear_mesh.c ../../geometry/cubic_lattice.c 1 2 3 4)
+#add_mpi_polymec_test(test_repartition_point_cloud test_repartition_point_cloud.c 1 2 3 4)
 
 # Mark tests expected to fail as such.
 foreach (failing_test ${failing_tests})

--- a/core/tests/test_adj_graph.c
+++ b/core/tests/test_adj_graph.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_avl_tree.c
+++ b/core/tests/test_avl_tree.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_cxx_program.cpp
+++ b/core/tests/test_cxx_program.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_declare_nd_array.c
+++ b/core/tests/test_declare_nd_array.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_exchanger.c
+++ b/core/tests/test_exchanger.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_file_utils.c
+++ b/core/tests/test_file_utils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_high_level_headers.c
+++ b/core/tests/test_high_level_headers.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_hilbert.c
+++ b/core/tests/test_hilbert.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_interpreter.c
+++ b/core/tests/test_interpreter.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_kd_tree.c
+++ b/core/tests/test_kd_tree.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_krylov_solver.c
+++ b/core/tests/test_krylov_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_least_squares.c
+++ b/core/tests/test_least_squares.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_mesh.c
+++ b/core/tests/test_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_mesh_node_exchangers.c
+++ b/core/tests/test_mesh_node_exchangers.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_newton.c
+++ b/core/tests/test_newton.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_options.c
+++ b/core/tests/test_options.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_ordered_map.c
+++ b/core/tests/test_ordered_map.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_ordered_set.c
+++ b/core/tests/test_ordered_set.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_parallel_qsort.c
+++ b/core/tests/test_parallel_qsort.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_partition_mesh.c
+++ b/core/tests/test_partition_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_partition_point_cloud.c
+++ b/core/tests/test_partition_point_cloud.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_polymec_init.c
+++ b/core/tests/test_polymec_init.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_polynomial.c
+++ b/core/tests/test_polynomial.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_repartition_mesh.c
+++ b/core/tests/test_repartition_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_repartition_point_cloud.c
+++ b/core/tests/test_repartition_point_cloud.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_special_functions.c
+++ b/core/tests/test_special_functions.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_string_utils.c
+++ b/core/tests/test_string_utils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_table.c
+++ b/core/tests/test_table.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_thread_pool.c
+++ b/core/tests/test_thread_pool.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_tuple.c
+++ b/core/tests/test_tuple.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_unordered_map.c
+++ b/core/tests/test_unordered_map.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tests/test_unordered_set.c
+++ b/core/tests/test_unordered_set.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/text_buffer.c
+++ b/core/text_buffer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/text_buffer.h
+++ b/core/text_buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/thread_pool.c
+++ b/core/thread_pool.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/thread_pool.h
+++ b/core/thread_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/timer.c
+++ b/core/timer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/timer.h
+++ b/core/timer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/tuple.h
+++ b/core/tuple.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/unordered_map.h
+++ b/core/unordered_map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/unordered_set.h
+++ b/core/unordered_set.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/core/write_silo.c
+++ b/core/write_silo.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -272,7 +272,7 @@ argument object in its construction process.
 Methods 
 -------
 
-A method for a class should have be named ``<CLASS>_<METHOD>`` and should 
+A method for a class should be named ``<CLASS>_<METHOD>`` and should 
 always take a pointer to the struct representing an instance of 
 that class as its first argument. For example, the following method returns 
 the distance between the given point and another point:
@@ -486,9 +486,9 @@ The following formatting rules are non-negotiable for source code in Polymec:
 
 The following guidelines are offered for readably formatted code:
 
-* If a function doesn't fit neatly on a line, break the line after an argument 
-  and align the following argument with its first. As long as the declaration 
-  and definition are clearly readable, it's fine.
+* If a function declaration doesn't fit neatly on a line, break the line after 
+  an argument and align the following argument with its first. As long as the 
+  declaration and definition are clearly readable, it's fine.
 * Curly braces that open and close new scopes each go on their own line, not 
   at the end of a line containing other code.
 * If a line is excessively long (in other words, if it doesn't fit on a single 

--- a/geometry/cartesian_1d.c
+++ b/geometry/cartesian_1d.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/coord_mapping.c
+++ b/geometry/coord_mapping.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/coord_mapping.h
+++ b/geometry/coord_mapping.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_boundary_generators.c
+++ b/geometry/create_boundary_generators.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_boundary_generators.h
+++ b/geometry/create_boundary_generators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_convex_hull.c
+++ b/geometry/create_convex_hull.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_convex_hull.h
+++ b/geometry/create_convex_hull.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_cubed_cylinder_mesh.c
+++ b/geometry/create_cubed_cylinder_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_cubed_cylinder_mesh.h
+++ b/geometry/create_cubed_cylinder_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_cubed_sphere_mesh.c
+++ b/geometry/create_cubed_sphere_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_cubed_sphere_mesh.h
+++ b/geometry/create_cubed_sphere_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_dual_mesh.c
+++ b/geometry/create_dual_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_dual_mesh.h
+++ b/geometry/create_dual_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_pebi_mesh.c
+++ b/geometry/create_pebi_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_pebi_mesh.h
+++ b/geometry/create_pebi_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_point_lattice.c
+++ b/geometry/create_point_lattice.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_point_lattice.h
+++ b/geometry/create_point_lattice.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_rectilinear_mesh.c
+++ b/geometry/create_rectilinear_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_rectilinear_mesh.h
+++ b/geometry/create_rectilinear_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_uniform_mesh.c
+++ b/geometry/create_uniform_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_uniform_mesh.h
+++ b/geometry/create_uniform_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_voronoi_mesh.c
+++ b/geometry/create_voronoi_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_voronoi_mesh.h
+++ b/geometry/create_voronoi_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_welded_block_mesh.c
+++ b/geometry/create_welded_block_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/create_welded_block_mesh.h
+++ b/geometry/create_welded_block_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/crop_mesh.c
+++ b/geometry/crop_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/crop_mesh.h
+++ b/geometry/crop_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/cubic_lattice.c
+++ b/geometry/cubic_lattice.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/cubic_lattice.h
+++ b/geometry/cubic_lattice.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/cylinder.c
+++ b/geometry/cylinder.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/cylinder.h
+++ b/geometry/cylinder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/cylindrical_1d.c
+++ b/geometry/cylindrical_1d.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/delaunay_triangulation.c
+++ b/geometry/delaunay_triangulation.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/delaunay_triangulation.h
+++ b/geometry/delaunay_triangulation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/difference.c
+++ b/geometry/difference.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/difference.h
+++ b/geometry/difference.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/generate_random_points.c
+++ b/geometry/generate_random_points.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/generate_random_points.h
+++ b/geometry/generate_random_points.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/giftwrap_hull.c
+++ b/geometry/giftwrap_hull.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/giftwrap_hull.h
+++ b/geometry/giftwrap_hull.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/interpreter_register_geometry_functions.c
+++ b/geometry/interpreter_register_geometry_functions.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/interpreter_register_geometry_functions.h
+++ b/geometry/interpreter_register_geometry_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/interpreter_register_spfuncs.c
+++ b/geometry/interpreter_register_spfuncs.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/intersection.c
+++ b/geometry/intersection.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/intersection.h
+++ b/geometry/intersection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/mesh_factory.c
+++ b/geometry/mesh_factory.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/plane.c
+++ b/geometry/plane.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/plane.h
+++ b/geometry/plane.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/point_factory.c
+++ b/geometry/point_factory.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/polygon.c
+++ b/geometry/polygon.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/polygon.h
+++ b/geometry/polygon.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/polygon2.c
+++ b/geometry/polygon2.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/polygon2.h
+++ b/geometry/polygon2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/rect_prism.c
+++ b/geometry/rect_prism.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/rect_prism.h
+++ b/geometry/rect_prism.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/rotate_mesh.c
+++ b/geometry/rotate_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/rotate_mesh.h
+++ b/geometry/rotate_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/scaled.c
+++ b/geometry/scaled.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/scaled.h
+++ b/geometry/scaled.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/sphere.c
+++ b/geometry/sphere.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/sphere.h
+++ b/geometry/sphere.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/spherical_1d.c
+++ b/geometry/spherical_1d.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/symmetry.h
+++ b/geometry/symmetry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/symmetry_1d.c
+++ b/geometry/symmetry_1d.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/generate_octave_script_for_surface.h
+++ b/geometry/tests/generate_octave_script_for_surface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_create_cubed_cylinder_mesh.c
+++ b/geometry/tests/test_create_cubed_cylinder_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_create_cubed_sphere_mesh.c
+++ b/geometry/tests/test_create_cubed_sphere_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_create_rectilinear_mesh.c
+++ b/geometry/tests/test_create_rectilinear_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_create_uniform_mesh.c
+++ b/geometry/tests/test_create_uniform_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_create_welded_block_mesh.c
+++ b/geometry/tests/test_create_welded_block_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_crop_mesh.c
+++ b/geometry/tests/test_crop_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_cylinder.c
+++ b/geometry/tests/test_cylinder.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_difference.c
+++ b/geometry/tests/test_difference.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_graph_from_mesh_cells.c
+++ b/geometry/tests/test_graph_from_mesh_cells.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_intersection.c
+++ b/geometry/tests/test_intersection.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_plane.c
+++ b/geometry/tests/test_plane.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_sphere.c
+++ b/geometry/tests/test_sphere.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tests/test_union.c
+++ b/geometry/tests/test_union.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tetrahedron.c
+++ b/geometry/tetrahedron.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/tetrahedron.h
+++ b/geometry/tetrahedron.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/translate_mesh.c
+++ b/geometry/translate_mesh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/translate_mesh.h
+++ b/geometry/translate_mesh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/union.c
+++ b/geometry/union.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/geometry/union.h
+++ b/geometry/union.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/am_ode_integrator.c
+++ b/integrators/am_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/am_ode_integrator.h
+++ b/integrators/am_ode_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ark_ode_integrator.c
+++ b/integrators/ark_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ark_ode_integrator.h
+++ b/integrators/ark_ode_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/bdf_ode_integrator.c
+++ b/integrators/bdf_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/bdf_ode_integrator.h
+++ b/integrators/bdf_ode_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/block_jacobi_newton_pc.c
+++ b/integrators/block_jacobi_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/block_jacobi_newton_pc.h
+++ b/integrators/block_jacobi_newton_pc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/cpr_differencer.c
+++ b/integrators/cpr_differencer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/cpr_differencer.h
+++ b/integrators/cpr_differencer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/cpr_newton_pc.c
+++ b/integrators/cpr_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/cpr_newton_pc.h
+++ b/integrators/cpr_newton_pc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/dae_integrator.c
+++ b/integrators/dae_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/dae_integrator.h
+++ b/integrators/dae_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/div_free_poly_basis.c
+++ b/integrators/div_free_poly_basis.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/div_free_poly_basis.h
+++ b/integrators/div_free_poly_basis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/euler_ode_integrator.c
+++ b/integrators/euler_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/euler_ode_integrator.h
+++ b/integrators/euler_ode_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/gauss_rules.c
+++ b/integrators/gauss_rules.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/gauss_rules.h
+++ b/integrators/gauss_rules.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/krylov_newton_pc.c
+++ b/integrators/krylov_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/krylov_newton_pc.h
+++ b/integrators/krylov_newton_pc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/newton_pc.c
+++ b/integrators/newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/newton_pc.h
+++ b/integrators/newton_pc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/newton_solver.c
+++ b/integrators/newton_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/newton_solver.h
+++ b/integrators/newton_solver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ode_integrator.c
+++ b/integrators/ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ode_integrator.h
+++ b/integrators/ode_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/polyhedron_integrator.c
+++ b/integrators/polyhedron_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/polyhedron_integrator.h
+++ b/integrators/polyhedron_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/sphere_integrator.c
+++ b/integrators/sphere_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/sphere_integrator.h
+++ b/integrators/sphere_integrator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ssor_newton_pc.c
+++ b/integrators/ssor_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/ssor_newton_pc.h
+++ b/integrators/ssor_newton_pc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/surface_integral.c
+++ b/integrators/surface_integral.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/surface_integral.h
+++ b/integrators/surface_integral.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/diurnal_integrator.c
+++ b/integrators/tests/diurnal_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/foodweb_solver.c
+++ b/integrators/tests/foodweb_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/heat2d_integrator.c
+++ b/integrators/tests/heat2d_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_ark_ode_integrator.c
+++ b/integrators/tests/test_ark_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_bdf_ode_integrator.c
+++ b/integrators/tests/test_bdf_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_cpr_differencer.c
+++ b/integrators/tests/test_cpr_differencer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_cpr_newton_pc.c
+++ b/integrators/tests/test_cpr_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_dae_integrator.c
+++ b/integrators/tests/test_dae_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_div_free_poly_basis.c
+++ b/integrators/tests/test_div_free_poly_basis.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_euler_ode_integrator.c
+++ b/integrators/tests/test_euler_ode_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_midpoint_polyhedron_integrator.c
+++ b/integrators/tests/test_midpoint_polyhedron_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_newton_solver.c
+++ b/integrators/tests/test_newton_solver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_sphere_integrator.c
+++ b/integrators/tests/test_sphere_integrator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/tests/test_ssor_newton_pc.c
+++ b/integrators/tests/test_ssor_newton_pc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/volume_integral.c
+++ b/integrators/volume_integral.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/integrators/volume_integral.h
+++ b/integrators/volume_integral.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/boundary_cell_map.c
+++ b/model/boundary_cell_map.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/boundary_cell_map.h
+++ b/model/boundary_cell_map.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/interpreter_register_model_functions.c
+++ b/model/interpreter_register_model_functions.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/interpreter_register_model_functions.h
+++ b/model/interpreter_register_model_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/mesh_stencils.c
+++ b/model/mesh_stencils.c
@@ -37,6 +37,9 @@ stencil_t* cell_star_stencil_new(mesh_t* mesh, int radius)
 {
   ASSERT(radius > 0);
 
+  if (radius > 1)
+    polymec_not_implemented("cell_star_stencil_new (radius > 1)");
+
   // First, we'll exchange the mesh cell centers to make sure they're 
   // consistent.
   exchanger_t* cell_ex = mesh_exchanger(mesh);
@@ -74,7 +77,9 @@ stencil_t* cell_star_stencil_new(mesh_t* mesh, int radius)
 
 stencil_t* cell_halo_stencil_new(mesh_t* mesh)
 {
-  // Construct a 1-deep star stencil.
+  POLYMEC_NOT_IMPLEMENTED;
+
+  // Construct a 2-deep star stencil to start from.
   stencil_t* star = cell_star_stencil_new(mesh, 1);
 
   // Now find the extra cells. The additional cells of a cell i are the 

--- a/model/mesh_stencils.c
+++ b/model/mesh_stencils.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/mesh_stencils.c
+++ b/model/mesh_stencils.c
@@ -74,18 +74,112 @@ stencil_t* cell_star_stencil_new(mesh_t* mesh, int radius)
 
 stencil_t* cell_halo_stencil_new(mesh_t* mesh)
 {
-  // Construct a slightly-bigger star stencil.
-  stencil_t* s = cell_star_stencil_new(mesh, 2);
+  // Construct a 1-deep star stencil.
+  stencil_t* star = cell_star_stencil_new(mesh, 1);
 
-  // Rename it.
-  polymec_free(s->name);
-  char name[1025];
-  snprintf(name, 1024, "cell halo stencil");
-  s->name = string_dup(name);
+  // Now find the extra cells. The additional cells of a cell i are the 
+  // neighbors of the neighbors of i that are 
+  // (1) not connected to i
+  // (2) connected to at least two of the neighbors of i.
 
-  // Now filter out the non-halo cells. 
+  // First, make a list of the local neighbors we are adding for each cell.
+  int_ptr_unordered_map_t* extra_neighbors = int_ptr_unordered_map_new();
+  int_unordered_set_t* neighbors_of_i = int_unordered_set_new();
+  for (int i = 0; i < star->num_indices; ++i)
+  {
+    // Make a list of the neighbors of i so we can filter them out.
+    int posj = 0, j;
+    while (stencil_next(star, i, &posj, &j, NULL))
+      int_unordered_set_insert(neighbors_of_i, j);
+
+    // Now traverse the neighbors of neighbors of i looking for extra halo 
+    // neighbors.
+    posj = 0;
+    while (stencil_next(star, i, &posj, &j, NULL))
+    {
+      // Populate the conn array with numbers of connections of each neighbor 
+      // of i's neighbors to neighbors of i (to evaluate (2) above).
+      int num_n_o_n = stencil_size(star, j);
+      int n_o_n[num_n_o_n];
+      stencil_get_neighbors(star, j, n_o_n);
+      int conn[num_n_o_n];
+      memset(conn, 0, sizeof(int) * num_n_o_n);
+      for (int kk = 0; kk < num_n_o_n; ++kk)
+      {
+        int k = n_o_n[kk];
+        if (!int_unordered_set_contains(neighbors_of_i, k)) // (1)
+        {
+          int posl = 0, l;
+          while (stencil_next(star, k, &posl, &l, NULL))
+          {
+            if (int_unordered_set_contains(neighbors_of_i, l))
+              ++conn[kk];
+          }
+        }
+      }
+
+      // Now record all the neighbors of neighbors of i that are connected 
+      // to 2 or more neighbors of i. (2)
+      for (int kk = 0; kk < num_n_o_n; ++kk)
+      {
+        if (conn[kk] >= 2)
+        {
+          int_array_t** halo_neighbors_p = (int_array_t**)int_ptr_unordered_map_get(extra_neighbors, i);
+          int_array_t* halo_neighbors;
+          if (halo_neighbors_p == NULL)
+          {
+            halo_neighbors = int_array_new();
+            int_ptr_unordered_map_insert_with_v_dtor(extra_neighbors, i, halo_neighbors, DTOR(int_array_free));
+          }
+          else
+            halo_neighbors = *halo_neighbors_p;
+          int k = n_o_n[kk];
+          int_array_append(halo_neighbors, k);
+        }
+      }
+    }
+
+    // Get ready to go again.
+    int_unordered_set_clear(neighbors_of_i);
+  }
+
+  // Make sure that these extra neighbors are communicated between parallel 
+  // domains. First we traverse all send cells and make lists of extra send 
+  // cells to add. Then we communicate the numbers of additional sent cells 
+  // to the receiving processes. Finally we count up the additional number of 
+  // ghost cells and make sure they are reflected in our exchanger.
+
+  // Traverse the send cells of the star stencil's exchanger and make lists 
+  // of extra send cells to add.
+
+  // Communicate the numbers of additional sent cells to our neighboring 
+  // processes.
+  int** send_data = (int**)exchanger_create_metadata_send_arrays(star->ex, MPI_INT, 1);
+  int** receive_data = (int**)exchanger_create_metadata_send_arrays(star->ex, MPI_INT, 1);
+
+  // Count up the needed ghost cells and make sure they are reflected in our 
+  // exchanger.
+  int num_halo_ghosts = stencil_num_ghosts(star);
   // FIXME
 
-  return s;
+  // Assemble the materials for the halo stencil.
+  int* halo_offsets = NULL;
+  int* halo_indices = NULL;
+  exchanger_t* halo_ex = exchanger_new(exchanger_comm(star->ex));
+
+  // Create the halo stencil.
+  stencil_t* halo = unweighted_stencil_new("cell halo stencil", 
+                                           star->num_indices,
+                                           halo_offsets, halo_indices, 
+                                           num_halo_ghosts, halo_ex);
+
+  // Clean up.
+  exchanger_free_metadata_send_arrays(star->ex, (void**)send_data);
+  exchanger_free_metadata_receive_arrays(star->ex, (void**)receive_data);
+  int_unordered_set_free(neighbors_of_i);
+  int_ptr_unordered_map_free(extra_neighbors);
+  stencil_free(star);
+
+  return halo;
 }
 

--- a/model/mesh_stencils.h
+++ b/model/mesh_stencils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/mesh_stencils.h
+++ b/model/mesh_stencils.h
@@ -16,12 +16,14 @@
 // cell from one of its neighboring cells. This unweighted stencil is 
 // constructed for every cell in the given mesh, and does not include the 
 // "central" cell.
+// NOTE: This stencil is not currently implemented for radius > 1!
 stencil_t* cell_star_stencil_new(mesh_t* mesh, int radius);
 
 // Creates a halo-shaped stencil for the cells in the given mesh. The halo 
 // consists of a single layer of cells surrounding the nodes of each cell.
 // This unweighted stencil is constructed for every cell in the given mesh, 
 // and does not include the "central" cell.
+// NOTE: This stencil is not currently implemented!
 stencil_t* cell_halo_stencil_new(mesh_t* mesh);
 
 #endif

--- a/model/model.c
+++ b/model/model.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/model.h
+++ b/model/model.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/neighbor_pairing.c
+++ b/model/neighbor_pairing.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/neighbor_pairing.h
+++ b/model/neighbor_pairing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/periodic_bc.c
+++ b/model/periodic_bc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/periodic_bc.h
+++ b/model/periodic_bc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/point_spacing_estimator.c
+++ b/model/point_spacing_estimator.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/point_spacing_estimator.h
+++ b/model/point_spacing_estimator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/point_weight_function.c
+++ b/model/point_weight_function.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/point_weight_function.h
+++ b/model/point_weight_function.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/polynomial_fit.c
+++ b/model/polynomial_fit.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/polynomial_fit.h
+++ b/model/polynomial_fit.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/stencil.c
+++ b/model/stencil.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/stencil.h
+++ b/model/stencil.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/CMakeLists.txt
+++ b/model/tests/CMakeLists.txt
@@ -2,49 +2,31 @@ include(add_polymec_test)
 
 add_polymec_test(test_polynomial_fit test_polynomial_fit.c)
 add_polymec_test(test_neighbor_pairing test_neighbor_pairing.c create_simple_pairing.c)
-add_mpi_polymec_test(test_stencil test_stencil.c 1 2 3 4)
+add_mpi_polymec_test(test_star_stencil test_star_stencil.c 1 2 3 4)
 
-function(add_game_of_life_test input num_steps diff)
-  if (HAVE_MPI EQUAL 1)
-    foreach (arg ${ARGN})
-      set(proc ${arg})
-      set(test_name game_of_life_${input}_${num_steps}_steps_${proc}_procs)
-      add_test(${test_name} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${proc} ${MPIEXEC_PREFLAGS} game_of_life run ${CMAKE_CURRENT_SOURCE_DIR}/patterns/${input}.lif t2=${num_steps} expect_diff=${diff} ${MPIEXEC_POSTFLAGS})
-      set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "expected == computed")
-    endforeach()
-  else()
-    set(test_name game_of_life_${input}_${num_steps}_steps)
-    add_test(${test_name} game_of_life run ${CMAKE_CURRENT_SOURCE_DIR}/patterns/${input}.lif t2=${num_steps} expect_diff=${diff})
-    set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "expected == computed")
-  endif()
-endfunction()
+# Tests for features we will add later.
+#add_mpi_polymec_test(test_halo_stencil test_halo_stencil.c 1 2 3 4)
+#function(add_game_of_life_test input num_steps diff)
+#  if (HAVE_MPI EQUAL 1)
+#    foreach (arg ${ARGN})
+#      set(proc ${arg})
+#      set(test_name game_of_life_${input}_${num_steps}_steps_${proc}_procs)
+#      add_test(${test_name} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${proc} ${MPIEXEC_PREFLAGS} game_of_life run ${CMAKE_CURRENT_SOURCE_DIR}/patterns/${input}.lif t2=${num_steps} expect_diff=${diff} ${MPIEXEC_POSTFLAGS})
+#      set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "expected == computed")
+#    endforeach()
+#  else()
+#    set(test_name game_of_life_${input}_${num_steps}_steps)
+#    add_test(${test_name} game_of_life run ${CMAKE_CURRENT_SOURCE_DIR}/patterns/${input}.lif t2=${num_steps} expect_diff=${diff})
+#    set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "expected == computed")
+#  endif()
+#endfunction()
 
-add_polymec_executable(game_of_life game_of_life.c)
-add_game_of_life_test(still 0 0 1 2 3 4)
-add_game_of_life_test(still 1 0 1 2 3 4)
-add_game_of_life_test(still 10 0 1 2 3 4)
+#add_polymec_executable(game_of_life game_of_life.c)
+#add_game_of_life_test(still 0 0 1 2 3 4)
+#add_game_of_life_test(still 1 0 1 2 3 4)
+#add_game_of_life_test(still 10 0 1 2 3 4)
 
-# The following tests are currently expected to fail.
-if (HAVE_MPI EQUAL 1)
-  set(failing_tests test_stencil_1_proc;test_stencil_2_proc;
-                    test_stencil_3_proc;test_stencil_4_proc;
-                    game_of_life_still_0_steps_1_procs;
-                    game_of_life_still_0_steps_2_procs;
-                    game_of_life_still_0_steps_3_procs;
-                    game_of_life_still_0_steps_4_procs;
-                    game_of_life_still_1_steps_1_procs;
-                    game_of_life_still_1_steps_2_procs;
-                    game_of_life_still_1_steps_3_procs;
-                    game_of_life_still_1_steps_4_procs;
-                    game_of_life_still_10_steps_1_procs;
-                    game_of_life_still_10_steps_2_procs;
-                    game_of_life_still_10_steps_3_procs;
-                    game_of_life_still_10_steps_4_procs)
-else()
-  set(failing_tests test_stencil_1_proc;
-                    game_of_life_still_1_steps;
-                    game_of_life_still_10_steps)
-endif()
+# The following tests (failing_tests) are currently expected to fail.
 foreach (failing_test ${failing_tests})
   set_tests_properties(${failing_test} PROPERTIES WILL_FAIL TRUE)
 endforeach()

--- a/model/tests/CMakeLists.txt
+++ b/model/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_game_of_life_test(still 10 0 1 2 3 4)
 if (HAVE_MPI EQUAL 1)
   set(failing_tests test_stencil_1_proc;test_stencil_2_proc;
                     test_stencil_3_proc;test_stencil_4_proc;
+                    game_of_life_still_0_steps_1_procs;
                     game_of_life_still_0_steps_2_procs;
                     game_of_life_still_0_steps_3_procs;
                     game_of_life_still_0_steps_4_procs;

--- a/model/tests/create_simple_pairing.c
+++ b/model/tests/create_simple_pairing.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/game_of_life.c
+++ b/model/tests/game_of_life.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/test_halo_stencil.c
+++ b/model/tests/test_halo_stencil.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/test_halo_stencil.c
+++ b/model/tests/test_halo_stencil.c
@@ -15,67 +15,6 @@
 #include "geometry/create_uniform_mesh.h"
 #include "model/mesh_stencils.h"
 
-void test_NXxNYxNZ_star_stencil(void** state, 
-                                MPI_Comm comm,
-                                int radius,
-                                int nx, int ny, int nz,
-                                int num_interior_neighbors, 
-                                int num_boundary_neighbors, 
-                                int num_edge_neighbors,
-                                int num_corner_neighbors)
-{
-  bbox_t bbox = {.x1 = 0.0, .x2 = 1.0, .y1 = 0.0, .y2 = 1.0, .z1 = 0.0, .z2 = 1.0};
-  mesh_t* mesh = create_uniform_mesh(comm, nx, ny, nz, &bbox);
-  cubic_lattice_t* lattice = cubic_lattice_new(nx, ny, nz);
-  stencil_t* stencil = cell_star_stencil_new(mesh, radius);
-  for (int i = 0; i < nx; ++i)
-  {
-    for (int j = 0; j < ny; ++j)
-    {
-      for (int k = 0; k < nz; ++k)
-      {
-        // The cell score is a way of telling whether we're in the 
-        // interior (0), on a boundary but not an edge/corner (1), on an 
-        // edge but not a corner (2), or on a corner (3).
-        int cell_score = 0;
-        if ((i == 0) || (i == nx-1))
-          ++cell_score;
-        if ((j == 0) || (j == ny-1))
-          ++cell_score;
-        if ((k == 0) || (k == nz-1))
-          ++cell_score;
-
-        // Count the number of neighbors.
-        int cell = cubic_lattice_cell(lattice, i, j, k);
-        int num_neighbors = stencil_size(stencil, cell);
-        if (cell_score == 0)
-          assert_int_equal(num_interior_neighbors, num_neighbors);
-        else if (cell_score == 1)
-          assert_int_equal(num_boundary_neighbors, num_neighbors);
-        else if (cell_score == 2)
-          assert_int_equal(num_edge_neighbors, num_neighbors);
-        else if (cell_score == 3)
-          assert_int_equal(num_corner_neighbors, num_neighbors);
-
-        // Make sure the neighbors are all valid, distinct cell indices.
-        int_unordered_set_t* neighbors = int_unordered_set_new();
-        int pos = 0, n;
-        real_t weight;
-        while (stencil_next(stencil, cell, &pos, &n, &weight))
-        {
-          assert_true(n >= 0);
-          assert_true(n < mesh->num_cells);
-          assert_false(int_unordered_set_contains(neighbors, n));
-          int_unordered_set_insert(neighbors, n);
-        }
-        int_unordered_set_free(neighbors);
-      }
-    }
-  }
-  stencil_free(stencil);
-  mesh_free(mesh);
-}
-
 void test_NXxNYxNZ_halo_stencil(void** state, 
                                 MPI_Comm comm,
                                 int nx, int ny, int nz,
@@ -136,26 +75,6 @@ void test_NXxNYxNZ_halo_stencil(void** state,
   mesh_free(mesh);
 }
 
-void test_serial_1x1x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 1, 1, 1, 0, 0, 0, 0);
-}
-
-void test_serial_10x1x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 1, 1, 0, 0, 2, 1);
-}
-
-void test_serial_10x10x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 1, 4, 4, 3, 2);
-}
-
-void test_serial_10x10x10_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 10, 6, 5, 4, 3);
-}
-
 void test_serial_1x1x1_cell_halo_stencil(void** state)
 {
   test_NXxNYxNZ_halo_stencil(state, MPI_COMM_SELF, 1, 1, 1, 0, 0, 0, 0);
@@ -174,31 +93,6 @@ void test_serial_10x10x1_cell_halo_stencil(void** state)
 void test_serial_10x10x10_cell_halo_stencil(void** state)
 {
   test_NXxNYxNZ_halo_stencil(state, MPI_COMM_SELF, 10, 10, 10, 26, 17, 11, 7);
-}
-
-void test_parallel_1x1x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 1, 1, 1, 0, 0, 0, 0);
-}
-
-void test_parallel_10x1x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 1, 1, 0, 0, 2, 1);
-}
-
-void test_parallel_10x10x1_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 1, 4, 4, 3, 2);
-}
-
-void test_parallel_10x10x10_cell_star_stencil(void** state)
-{
-  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 10, 6, 5, 4, 3);
-}
-
-void test_parallel_1x1x1_cell_halo_stencil(void** state)
-{
-  test_NXxNYxNZ_halo_stencil(state, MPI_COMM_WORLD, 1, 1, 1, 0, 0, 0, 0);
 }
 
 void test_parallel_10x1x1_cell_halo_stencil(void** state)
@@ -221,21 +115,12 @@ int main(int argc, char* argv[])
   polymec_init(argc, argv);
   const UnitTest tests[] = 
   {
-    unit_test(test_serial_1x1x1_cell_star_stencil),
-    unit_test(test_serial_10x1x1_cell_star_stencil),
-    unit_test(test_serial_10x10x1_cell_star_stencil),
-    unit_test(test_serial_10x10x10_cell_star_stencil),
     unit_test(test_serial_1x1x1_cell_halo_stencil),
     unit_test(test_serial_10x1x1_cell_halo_stencil),
     unit_test(test_serial_10x10x1_cell_halo_stencil),
     unit_test(test_serial_10x10x10_cell_halo_stencil)
 #if POLYMEC_HAVE_MPI
-   ,unit_test(test_parallel_1x1x1_cell_star_stencil),
-    unit_test(test_parallel_10x1x1_cell_star_stencil),
-    unit_test(test_parallel_10x10x1_cell_star_stencil),
-    unit_test(test_parallel_10x10x10_cell_star_stencil),
-    unit_test(test_parallel_1x1x1_cell_halo_stencil),
-    unit_test(test_parallel_10x1x1_cell_halo_stencil),
+   ,unit_test(test_parallel_10x1x1_cell_halo_stencil),
     unit_test(test_parallel_10x10x1_cell_halo_stencil),
     unit_test(test_parallel_10x10x10_cell_halo_stencil)
 #endif

--- a/model/tests/test_neighbor_pairing.c
+++ b/model/tests/test_neighbor_pairing.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/test_polynomial_fit.c
+++ b/model/tests/test_polynomial_fit.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/model/tests/test_star_stencil.c
+++ b/model/tests/test_star_stencil.c
@@ -1,0 +1,134 @@
+// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// All rights reserved.
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include "cmockery.h"
+#include "core/unordered_set.h"
+#include "geometry/cubic_lattice.h"
+#include "geometry/create_uniform_mesh.h"
+#include "model/mesh_stencils.h"
+
+void test_NXxNYxNZ_star_stencil(void** state, 
+                                MPI_Comm comm,
+                                int radius,
+                                int nx, int ny, int nz,
+                                int num_interior_neighbors, 
+                                int num_boundary_neighbors, 
+                                int num_edge_neighbors,
+                                int num_corner_neighbors)
+{
+  bbox_t bbox = {.x1 = 0.0, .x2 = 1.0, .y1 = 0.0, .y2 = 1.0, .z1 = 0.0, .z2 = 1.0};
+  mesh_t* mesh = create_uniform_mesh(comm, nx, ny, nz, &bbox);
+  int rank, nprocs;
+  MPI_Comm_rank(comm, &rank);
+  MPI_Comm_size(comm, &nprocs);
+  int num_cells[nprocs];
+  MPI_Allgather(&mesh->num_cells, 1, MPI_INT, num_cells, 1, MPI_INT, comm);
+  int cell_offset = 0;
+  for (int p = 0; p < rank; ++p)
+    cell_offset += num_cells[p];
+  cubic_lattice_t* lattice = cubic_lattice_new(nx, ny, nz);
+  stencil_t* stencil = cell_star_stencil_new(mesh, radius);
+  for (int cell = cell_offset; cell < cell_offset + mesh->num_cells; ++cell)
+  {
+    index_t i, j, k;
+    cubic_lattice_get_cell_triple(lattice, (index_t)cell, &i, &j, &k);
+
+    // The cell score is a way of telling whether we're in the 
+    // interior (0), on a boundary but not an edge/corner (1), on an 
+    // edge but not a corner (2), or on a corner (3).
+    int cell_score = 0;
+    if ((i == 0) || (i == nx-1))
+      ++cell_score;
+    if ((j == 0) || (j == ny-1))
+      ++cell_score;
+    if ((k == 0) || (k == nz-1))
+      ++cell_score;
+
+    // Count the number of neighbors.
+    int c = cell - cell_offset;
+    int num_neighbors = stencil_size(stencil, c);
+    if (cell_score == 0)
+      assert_int_equal(num_interior_neighbors, num_neighbors);
+    else if (cell_score == 1)
+      assert_int_equal(num_boundary_neighbors, num_neighbors);
+    else if (cell_score == 2)
+      assert_int_equal(num_edge_neighbors, num_neighbors);
+    else if (cell_score == 3)
+      assert_int_equal(num_corner_neighbors, num_neighbors);
+
+    // Make sure the neighbors are all valid, distinct cell indices.
+    int_unordered_set_t* neighbors = int_unordered_set_new();
+    int pos = 0, n;
+    real_t weight;
+    while (stencil_next(stencil, c, &pos, &n, &weight))
+    {
+      assert_true(n >= 0);
+      assert_false(int_unordered_set_contains(neighbors, n));
+      int_unordered_set_insert(neighbors, n);
+    }
+    int_unordered_set_free(neighbors);
+  }
+  stencil_free(stencil);
+  mesh_free(mesh);
+}
+
+void test_serial_1x1x1_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 1, 1, 1, 0, 0, 0, 0);
+}
+
+void test_serial_10x1x1_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 1, 1, 0, 0, 2, 1);
+}
+
+void test_serial_10x10x1_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 1, 4, 4, 3, 2);
+}
+
+void test_serial_10x10x10_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 10, 6, 5, 4, 3);
+}
+
+void test_parallel_10x1x1_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 1, 1, 0, 0, 2, 1);
+}
+
+void test_parallel_10x10x1_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 1, 4, 4, 3, 2);
+}
+
+void test_parallel_10x10x10_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 10, 6, 5, 4, 3);
+}
+
+int main(int argc, char* argv[]) 
+{
+  polymec_init(argc, argv);
+  const UnitTest tests[] = 
+  {
+    unit_test(test_serial_1x1x1_cell_star_stencil),
+    unit_test(test_serial_10x1x1_cell_star_stencil),
+    unit_test(test_serial_10x10x1_cell_star_stencil),
+    unit_test(test_serial_10x10x10_cell_star_stencil)
+#if POLYMEC_HAVE_MPI
+   ,unit_test(test_parallel_10x1x1_cell_star_stencil),
+    unit_test(test_parallel_10x10x1_cell_star_stencil),
+    unit_test(test_parallel_10x10x10_cell_star_stencil)
+#endif
+  };
+  return run_tests(tests);
+}

--- a/model/tests/test_star_stencil.c
+++ b/model/tests/test_star_stencil.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/mpi_serial/mpi.h
+++ b/mpi_serial/mpi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/mpi_serial/mpi_serial.c
+++ b/mpi_serial/mpi_serial.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_controller.c
+++ b/multiphysics/physics_controller.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_controller.h
+++ b/multiphysics/physics_controller.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_kernel.c
+++ b/multiphysics/physics_kernel.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_kernel.h
+++ b/multiphysics/physics_kernel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_state.c
+++ b/multiphysics/physics_state.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/multiphysics/physics_state.h
+++ b/multiphysics/physics_state.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015, Jeffrey N. Johnson
+// Copyright (c) 2012-2016, Jeffrey N. Johnson
 // All rights reserved.
 // 
 // This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/prepend_license.py
+++ b/tools/prepend_license.py
@@ -1,6 +1,6 @@
 """prepend_license.py -- prepends license information to all source files."""
 
-license_text = """Copyright (c) 2012-2015, Jeffrey N. Johnson
+license_text = """Copyright (c) 2012-2016, Jeffrey N. Johnson
 All rights reserved.
 
 This Source Code Form is subject to the terms of the Mozilla Public
@@ -10,26 +10,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/."""
 old_license_text = """Copyright (c) 2012-2015, Jeffrey N. Johnson
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this 
-list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, 
-this list of conditions and the following disclaimer in the documentation 
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."""
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/."""
 
 import os.path
 
@@ -56,7 +39,8 @@ def remove_old_license(source_file):
     old_license_lines = old_license_text.split('\n')
     has_old_license = True
     for i in xrange(len(lines)):
-        if old_license_lines[i] not in lines[i]:
+        if (i < len(old_license_lines)) and \
+           (old_license_lines[i] not in lines[i]):
             has_old_license = False
             break
 


### PR DESCRIPTION
* Halo cell stencils and augmented star cell stencils are beyond the scope of v1.0.
* Dynamic mesh repartitioning and parallel quicksort are also beyond v1.0.
* Deactivated features that aren't making it into v1.0.
* Bumped copyright dates on license headers to 2016.
* Fixed parallel star stencil unit tests.