### PR TITLE
Some bugfixes in the model library.

### DIFF
--- a/model/interpreter.c
+++ b/model/interpreter.c
@@ -135,7 +135,7 @@ static void destroy_variable(char* key, interpreter_storage_t* value)
 {
   if ((value->dtor != NULL) && (value->owner == LUA))
   {
-    log_debug("interpreter: destroying %s (deallocating)", key);
+    log_debug("interpreter: destroying %s", key);
     (*value->dtor)(value->datum);
   }
   else

--- a/model/interpreter_register_spfuncs.c
+++ b/model/interpreter_register_spfuncs.c
@@ -75,9 +75,15 @@ static void bnj_eval(void* context, point_t* x, real_t t, real_t* val)
   point_displacement(&bnj->x0, x, &y);
   if (vector_mag(&y) < bnj->ball_radius) // inside the ball
   {
-    if ((ABS(y.x) <= bnj->jack_thickness) || 
-        (ABS(y.y) <= bnj->jack_thickness) || 
-        (ABS(y.z) <= bnj->jack_thickness)) // inside the jack
+    if (((ABS(y.x) <= 0.5*bnj->jack_length) && 
+         (ABS(y.y) <= 0.5*bnj->jack_thickness) && 
+         (ABS(y.z) <= 0.5*bnj->jack_thickness)) || 
+        ((ABS(y.x) <= 0.5*bnj->jack_thickness) && 
+         (ABS(y.y) <= 0.5*bnj->jack_length) && 
+         (ABS(y.z) <= 0.5*bnj->jack_thickness)) || 
+        ((ABS(y.x) <= 0.5*bnj->jack_thickness) && 
+         (ABS(y.y) <= 0.5*bnj->jack_thickness) && 
+         (ABS(y.z) <= 0.5*bnj->jack_length)))
       *val = bnj->jack_value;
     else
       *val = bnj->ball_value;
@@ -102,10 +108,10 @@ static int ball_and_jack(lua_State* lua)
     return luaL_error(lua, "ball_and_jack: ball radius must be positive.");
   real_t ball_value = (real_t)lua_tonumber(lua, 3);
   real_t jack_size = (real_t)lua_tonumber(lua, 4);
-  real_t jack_thickness = jack_size / 5.0;
+  real_t jack_thickness = jack_size / 4.0;
   if (jack_size <= 0.0)
     return luaL_error(lua, "ball_and_jack: jack size must be positive.");
-  else if (sqrt(jack_size*jack_size + jack_thickness*jack_thickness) > ball_radius)
+  else if (sqrt(0.25*jack_size*jack_size + 0.25*jack_thickness*jack_thickness) > ball_radius)
     return luaL_error(lua, "ball_and_jack: jack size is too large to fit within ball radius.");
 
   real_t jack_value = (real_t)lua_tonumber(lua, 5);

--- a/model/model.c
+++ b/model/model.c
@@ -777,7 +777,15 @@ real_t model_max_dt(model_t* model, char* reason)
 
   // Now let the model have at it.
   if (model->vtable.max_dt != NULL)
-    dt = model->vtable.max_dt(model->context, model->time, reason);
+  {
+    char model_reason[POLYMEC_MODEL_MAXDT_REASON_SIZE+1];
+    real_t model_dt = model->vtable.max_dt(model->context, model->time, model_reason);
+    if (model_dt < dt)
+    {
+      dt = model_dt;
+      strcpy(reason, model_reason);
+    }
+  }
   return dt;
 }
 
@@ -1181,7 +1189,7 @@ void model_run(model_t* model, real_t t1, real_t t2, int max_steps)
     // Now run the calculation.
     while ((model->time < t2) && (model->step < max_steps))
     {
-      char reason[POLYMEC_MODEL_MAXDT_REASON_SIZE];
+      char reason[POLYMEC_MODEL_MAXDT_REASON_SIZE+1];
       real_t max_dt;
       if (model->step == 0)
       {


### PR DESCRIPTION
* Fixed a bug in the setting of the maximum timestep -- if the model-specific timestep was larger than the timestep determined by generic constraints (observation, plot, end of simulation), it was still being used.
* Fixed the ball_and_jack lua st_func for the interpreter. 
* Fixed some text in a log entry.