### PR TITLE
Fixed another bug setting max_dt on the first step.

### DIFF
--- a/model/model.c
+++ b/model/model.c
@@ -1190,14 +1190,15 @@ void model_run(model_t* model, real_t t1, real_t t2, int max_steps)
     while ((model->time < t2) && (model->step < max_steps))
     {
       char reason[POLYMEC_MODEL_MAXDT_REASON_SIZE+1];
-      real_t max_dt;
+      real_t max_dt = model_max_dt(model, reason);
       if (model->step == 0)
       {
-        max_dt = model->initial_dt;
-        snprintf(reason, POLYMEC_MODEL_MAXDT_REASON_SIZE, "Initial time step size");
+        if (model->initial_dt < max_dt)
+        {
+          max_dt = model->initial_dt;
+          snprintf(reason, POLYMEC_MODEL_MAXDT_REASON_SIZE, "Initial time step size");
+        }
       }
-      else 
-        max_dt = model_max_dt(model, reason);
       if (max_dt > t2 - model->time)
       {
         max_dt = t2 - model->time;


### PR DESCRIPTION
The model wasn't using its max dt calculation for the first time step--it was only using the initial dt, if specified.