### PR TITLE
Exchangers/migrators are now garbage collected.

### DIFF
--- a/core/exchanger.h
+++ b/core/exchanger.h
@@ -23,6 +23,7 @@ exchanger_t* exchanger_new(MPI_Comm comm);
 exchanger_t* exchanger_new_with_rank(MPI_Comm comm, int rank);
 
 // Destroys an exchanger.
+// This function is deprecated.
 void exchanger_free(exchanger_t* ex);
 
 // Creates a complete copy of the given exchanger.
@@ -237,6 +238,7 @@ migrator_t* migrator_from_local_partition(MPI_Comm comm,
                                           int num_local_vertices);
 
 // Destroys a migrator.
+// This function is deprecated.
 void migrator_free(migrator_t* m);
 
 // Creates a complete copy of the given migrator.

--- a/core/mesh.c
+++ b/core/mesh.c
@@ -42,7 +42,7 @@ static mesh_storage_t* mesh_storage_new(MPI_Comm comm)
 // Frees the given storage mechanism.
 static void mesh_storage_free(mesh_storage_t* storage)
 {
-  exchanger_free(storage->exchanger);
+  storage->exchanger = NULL;
   polymec_free(storage);
 }
 
@@ -336,7 +336,7 @@ void mesh_set_exchanger(mesh_t* mesh, exchanger_t* ex)
 {
   ASSERT(ex != NULL);
   if (mesh->storage->exchanger != NULL)
-    exchanger_free(mesh->storage->exchanger);
+    mesh->storage->exchanger = NULL;
   mesh->storage->exchanger = ex;
 }
 
@@ -686,7 +686,7 @@ static void* mesh_byte_read(byte_array_t* bytes, size_t* offset)
   byte_array_read_ints(bytes, 1, &storage->cell_face_capacity, offset);
   byte_array_read_ints(bytes, 1, &storage->face_edge_capacity, offset);
   byte_array_read_ints(bytes, 1, &storage->face_node_capacity, offset);
-  exchanger_free(storage->exchanger);
+  storage->exchanger = NULL;
   ser = exchanger_serializer();
   storage->exchanger = serializer_read(ser, bytes, offset);
 
@@ -788,7 +788,7 @@ exchanger_t* mesh_1v_face_exchanger_new(mesh_t* mesh)
   exchanger_set_receives(ex, send_map);
   int_ptr_unordered_map_free(send_map);
   int_ptr_unordered_map_free(receive_map);
-  exchanger_free(face2_ex);
+  face2_ex = NULL;
   return ex;
 }
 

--- a/core/mesh_node_exchangers.c
+++ b/core/mesh_node_exchangers.c
@@ -90,7 +90,7 @@ exchanger_t* mesh_1v_node_exchanger_new(mesh_t* mesh)
   exchanger_set_receives(ex, receive_map);
   int_ptr_unordered_map_free(send_map);
   int_ptr_unordered_map_free(receive_map);
-  exchanger_free(noden_ex);
+  noden_ex = NULL;
 #endif
   return ex;
 }

--- a/core/tests/test_exchanger.c
+++ b/core/tests/test_exchanger.c
@@ -15,7 +15,7 @@
 void test_exchanger_new(void** state)
 {
   exchanger_t* exchanger = exchanger_new(MPI_COMM_WORLD);
-  exchanger_free(exchanger);
+  exchanger = NULL;
 }
 
 void test_exchanger_construct(void** state)
@@ -37,7 +37,7 @@ void test_exchanger_construct(void** state)
       send_indices[i] = i;
     exchanger_set_receive(exchanger, (rank+nproc-1) % nproc, receive_indices, N/nproc, true);
   }
-  exchanger_free(exchanger);
+  exchanger = NULL;
 }
 
 void test_exchanger_construct_and_delete(void** state)
@@ -62,7 +62,7 @@ void test_exchanger_construct_and_delete(void** state)
     exchanger_delete_send(exchanger, 1);
     exchanger_delete_receive(exchanger, 1);
   }
-  exchanger_free(exchanger);
+  exchanger = NULL;
 }
 
 int main(int argc, char* argv[]) 

--- a/core/tests/test_kd_tree.c
+++ b/core/tests/test_kd_tree.c
@@ -120,7 +120,7 @@ void test_find_ghost_points(void** state)
   }
 
   // Clean up.
-  exchanger_free(ex);
+  ex = NULL;
   kd_tree_free(tree);
 }
 

--- a/core/tests/test_mesh_node_exchangers.c
+++ b/core/tests/test_mesh_node_exchangers.c
@@ -63,7 +63,7 @@ void test_nv_node_exchanger_on_line(void** state)
     }
   }
 
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -101,7 +101,7 @@ void test_1v_node_exchanger_on_line(void** state)
     }
   }
 
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -137,7 +137,7 @@ void test_nv_node_exchanger_in_plane(void** state)
   }
   exchanger_fprintf(ex, stdout);
   exchanger_verify(ex, polymec_error);
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -152,7 +152,7 @@ void test_1v_node_exchanger_in_plane(void** state)
   exchanger_t* ex = mesh_1v_node_exchanger_new(mesh);
   exchanger_fprintf(ex, stdout);
   exchanger_verify(ex, polymec_error);
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -188,7 +188,7 @@ void test_nv_node_exchanger_in_cube(void** state)
   }
   exchanger_fprintf(ex, stdout);
   exchanger_verify(ex, polymec_error);
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -203,7 +203,7 @@ void test_1v_node_exchanger_in_cube(void** state)
   exchanger_t* ex = mesh_1v_node_exchanger_new(mesh);
   exchanger_fprintf(ex, stdout);
   exchanger_verify(ex, polymec_error);
-  exchanger_free(ex);
+  ex = NULL;
   mesh_free(mesh);
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/model/stencil.c
+++ b/model/stencil.c
@@ -43,7 +43,7 @@ void stencil_free(stencil_t* stencil)
   polymec_free(stencil->indices);
   if (stencil->weights != NULL)
     polymec_free(stencil->weights);
-  exchanger_free(stencil->ex);
+  stencil->ex = NULL;
   polymec_free(stencil);
 }
 


### PR DESCRIPTION
Their destructor functions are now deprecated.

Fixes #165.