### PR TITLE
More compiler flags, no more fabs().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-compare -Wno-unused-parameter -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wno-unused-function")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-reserved-id-macro -Wno-unused-macros -Wno-sign-conversion -Wno-padded -Wno-vla")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-nonliteral -Wno-cast-qual -Wno-switch-enum -Wno-unknown-pragmas -Wno-source-uses-openmp")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-warning-option")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-warning-option -Wno-documentation-deprecated-sync")
 
   # Deal with older versions of Clang.
   if (NOT CMAKE_C_COMPILER_ID MATCHES "AppleClang" AND CMAKE_C_COMPILER_VERSION STRLESS "3.6")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Weverything -Werror -pedantic-errors -Werror-implicit-function-declaration -fno-builtin")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-sign-compare -Wno-unused-parameter -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wno-unused-function")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-reserved-id-macro -Wno-unused-macros -Wno-sign-conversion -Wno-padded -Wno-vla")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-nonliteral -Wno-cast-qual -Wno-switch-enum -Wno-unknown-pragmas")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-nonliteral -Wno-cast-qual -Wno-switch-enum -Wno-unknown-pragmas -Wno-source-uses-openmp")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-warning-option")
 
   # Deal with older versions of Clang.

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -1626,7 +1626,7 @@ krylov_factory_t* hypre_krylov_factory(const char* hypre_dir)
     polymec_error("hypre_krylov_factory: %s.", msg);
   }
 
-#if APPLE
+#if defined(APPLE) && APPLE == 1
   // Mac-specific trick: 
   // If the HYPRE library is parallel, it will contain a reference to MPI symbols, 
   // even if those symbols are not defined within the library itself.

--- a/core/mesh.c
+++ b/core/mesh.c
@@ -489,7 +489,7 @@ void mesh_compute_geometry(mesh_t* mesh)
         point_displacement(xf, &xn1, &v2);
         point_displacement(xf, &xn2, &v3);
         vector_cross(&v2, &v3, &v2xv3);
-        real_t tet_volume = fabs(vector_dot(&v1, &v2xv3))/6.0;
+        real_t tet_volume = ABS(vector_dot(&v1, &v2xv3))/6.0;
         mesh->cell_volumes[cell] += tet_volume;
 
         // Now take the face of the tet whose vertices are the face center 

--- a/core/newton.c
+++ b/core/newton.c
@@ -184,7 +184,7 @@ real_t brent_solve(real_t (*F)(void*, real_t), void* context, real_t x1, real_t 
   real_t fb = F(context, b);
   if (fa * fb >= 0.0)
     polymec_error("brent_solve: Root is not bracketed by [x1, x2].");
-  if (fabs(fa) < fabs(fb))
+  if (ABS(fa) < ABS(fb))
   {
     real_t tmp1 = b, tmp2 = fb;
     b = a;
@@ -233,7 +233,7 @@ real_t brent_solve(real_t (*F)(void*, real_t), void* context, real_t x1, real_t 
       a = s;
       fa = fs;
     }
-    if (fabs(fa) < fabs(fb))
+    if (ABS(fa) < ABS(fb))
     {
       real_t tmp1 = b, tmp2 = fb;
       b = a;
@@ -243,7 +243,7 @@ real_t brent_solve(real_t (*F)(void*, real_t), void* context, real_t x1, real_t 
     }
     ++num_iter;
   }
-  while ((MAX(fabs(fb), fabs(fs)) > tolerance) && (num_iter < max_iters));
-  return (fabs(fb) < fabs(fs)) ? b : s;
+  while ((MAX(ABS(fb), ABS(fs)) > tolerance) && (num_iter < max_iters));
+  return (ABS(fb) < ABS(fs)) ? b : s;
 }
 

--- a/core/newton.h
+++ b/core/newton.h
@@ -14,7 +14,7 @@
 // the interval [x1, x2] with the specified maximum number of iterations 
 // and desired tolerance. F is a function that takes a user-defined context and 
 // a value x and returns F(x). This function returns the solution x which 
-// satisfies fabs(F(x)) = tolerance.
+// satisfies ABS(F(x)) = tolerance.
 real_t brent_solve(real_t (*F)(void*, real_t), void* context, real_t x1, real_t x2, real_t tolerance, int max_iters); 
 
 // This class solves (dense) systems of nonlinear equations using 

--- a/core/norms.h
+++ b/core/norms.h
@@ -15,7 +15,7 @@ static inline real_t l1_norm(real_t* vec, int dim)
 {
   real_t sum = 0.0;
   for (int i = 0; i < dim; ++i)
-    sum += fabs(vec[i]);
+    sum += ABS(vec[i]);
   return sum;
 }
 
@@ -33,7 +33,7 @@ static inline real_t linf_norm(real_t* vec, int dim)
 {
   real_t max = -REAL_MAX;
   for (int i = 0; i < dim; ++i)
-    max = MAX(max, fabs(vec[i]));
+    max = MAX(max, ABS(vec[i]));
   return max;
 }
 

--- a/core/point.c
+++ b/core/point.c
@@ -97,7 +97,7 @@ void bbox_make_empty_set(bbox_t* box)
 
 void compute_orthonormal_basis(vector_t* e1, vector_t* e2, vector_t* e3)
 {
-  ASSERT(fabs(vector_mag(e1) - 1.0) < 1e-14);
+  ASSERT(reals_equal(vector_mag(e1), 1.0));
 
   // Pick an arbitrary vector, e2, that is perpendicular to e1. One of these
   // should work.

--- a/core/point.h
+++ b/core/point.h
@@ -223,9 +223,9 @@ static inline bool bbox_intersects_bbox(bbox_t* box1, bbox_t* box2)
   point_t x2 = {.x = 0.5 * (box2->x1 + box2->x2),
                 .y = 0.5 * (box2->y1 + box2->y2),
                 .z = 0.5 * (box2->z1 + box2->z2)};
-  return ((fabs(x1.x - x2.x) * 2.0 <= (box1->x2 - box1->x1 + box2->x2 - box2->x1)) && 
-          (fabs(x1.y - x2.y) * 2.0 <= (box1->y2 - box1->y1 + box2->y2 - box2->y1)) &&
-          (fabs(x1.z - x2.z) * 2.0 <= (box1->z2 - box1->z1 + box2->z2 - box2->z1)));
+  return ((ABS(x1.x - x2.x) * 2.0 <= (box1->x2 - box1->x1 + box2->x2 - box2->x1)) && 
+          (ABS(x1.y - x2.y) * 2.0 <= (box1->y2 - box1->y1 + box2->y2 - box2->y1)) &&
+          (ABS(x1.z - x2.z) * 2.0 <= (box1->z2 - box1->z1 + box2->z2 - box2->z1)));
 }
 
 // Intersects box1 with box2, overwriting the bounding coordinates in intersection. If box1 and box2

--- a/core/polymec.c
+++ b/core/polymec.c
@@ -318,8 +318,14 @@ static void pause_if_requested()
     {
       log_urgent("Pausing for %d seconds. PIDS: ", secs);
       int pid = (int)getpid();
-      char hostname[32];
-      gethostname(hostname, 32);
+#if POLYMEC_HAVE_MPI
+      char hostname[MPI_MAX_PROCESSOR_NAME];
+      int name_len;
+      MPI_Get_processor_name(hostname, &name_len);
+#else
+      char hostname[256];
+      gethostname(hostname, 256);
+#endif
       int pids[world_nprocs];
       char hostnames[32*world_nprocs];
       MPI_Gather(&pid, 1, MPI_INT, pids, 1, MPI_INT, 0, MPI_COMM_WORLD);

--- a/core/polymec.h.in
+++ b/core/polymec.h.in
@@ -16,19 +16,19 @@
 
 // We require the availability of variable-length arrays, which where 
 // mandatory in C99 but are optional in C11.
-#if defined __STDC_NO_VLA__ && __STDC_NO_VLA__ == 1
+#if defined(__STDC_NO_VLA__) && __STDC_NO_VLA__ == 1
 #error "Polymec requires the availability of variable-length arrays (VLA), which this compiler does not support."
 #endif
 
 // In a perfect world, we'd have full support for IEEE 754 floating point 
 // arithmetic. The world in which we live is not presently perfect.
-//#if !defined __STDC_IEC_559__ || __STDC_IEC_559__ == 0
+//#if !defined(__STDC_IEC_559__) || __STDC_IEC_559__ == 0
 //#error "Polymec requires IEC 60559 (IEEE 754) floating point arithmetic support."
 //#endif
 
 // The Annex K bounds-checking interfaces would be really nice to have, and 
 // someday we shall have them, but not today.
-//#if !defined __STDC_LIB_EXT1__ || __STDC_LIB_EXT1__ == 0
+//#if !defined(__STDC_LIB_EXT1__) || __STDC_LIB_EXT1__ == 0
 //#error "Polymec requires the availability of the bounds-checking interfaces in Annex K, which this compiler does not support."
 //#endif
 

--- a/core/polynomial.c
+++ b/core/polynomial.c
@@ -552,7 +552,7 @@ void polynomial_fprintf(polynomial_t* p, FILE* stream)
     else if (!reals_equal(coeff, 1.0) && !reals_equal(coeff, 0.0))
     {
       if (pos > 1)
-        fprintf(stream, "%g ", fabs(coeff));
+        fprintf(stream, "%g ", ABS(coeff));
       else
         fprintf(stream, "%g ", coeff);
     }

--- a/core/special_functions.c
+++ b/core/special_functions.c
@@ -41,9 +41,9 @@ double gamma(double x)
 
   double z, r = 1.0;
   int m;
-  if (fabs(x) > 1.0)
+  if (ABS(x) > 1.0)
   {
-    z = fabs(x);
+    z = ABS(x);
     m = (int)z;
     for (int i = 1; i <= m; ++i)
       r *= (z - i);
@@ -69,7 +69,7 @@ double gamma(double x)
   for (int i = 0; i < 25; ++i)
      gr = gr*z + g[24-i];
   double ga = 1.0 / (gr*z);
-  if (fabs(x) > 1.0)
+  if (ABS(x) > 1.0)
   {
     ga *= r;
     if (x < 0.0) 
@@ -124,7 +124,7 @@ double bessel_j0(double x)
     {
       r = -0.25*r*x2/(k*k);
       val += r;
-      if (fabs(r) < 1e-15*fabs(val)) break;
+      if (ABS(r) < 1e-15*ABS(val)) break;
     }
   }
   else
@@ -163,7 +163,7 @@ double bessel_j1(double x)
     {
       r = -0.25*r*x2/(k*(k+1));
       val += r;
-      if (fabs(r) < 1e-15*fabs(val)) break;
+      if (ABS(r) < 1e-15*ABS(val)) break;
     }
     val *= 0.5*x;
   }
@@ -196,7 +196,7 @@ static inline double envj(int n, double x)
 
 static double msta1(double x, double mp)
 {
-  double a0 = fabs(x);
+  double a0 = ABS(x);
   int n0 = (int)(1.1*a0) + 1;
   double f0 = envj(n0, a0) - mp;
   int n1 = n0 + 5;
@@ -206,7 +206,7 @@ static double msta1(double x, double mp)
   {
     nn = n1 - 1.0*(n1-n0)/(1.0 - f0/f1);
     double f = envj((int)nn, a0) - mp;
-    if (fabs(nn-n1) < 1.0) break;
+    if (ABS(nn-n1) < 1.0) break;
     n0 = n1;
     f0 = f1;
     n1 = (int)nn;
@@ -217,7 +217,7 @@ static double msta1(double x, double mp)
 
 static double msta2(double x, int n, double mp)
 {
-  double a0 = fabs(x);
+  double a0 = ABS(x);
   double hmp = 0.5 * mp;
   double ejn = envj(n, a0);
   double obj;
@@ -240,7 +240,7 @@ static double msta2(double x, int n, double mp)
   {
     nn = 1.0*n1 - 1.0*(n1 - n0)/(1.0 - f0/f1);
     double f = envj((int)nn, a0) - obj;
-    if (fabs(nn-n1) < 1.0) break;
+    if (ABS(nn-n1) < 1.0) break;
     n0 = n1;
     f0 = f1;
     n1 = (int)nn;
@@ -288,7 +288,7 @@ double bessel_jn(int n, double x)
       f1 = f;
     }
     double cs;
-    if (fabs(j0_val) > fabs(j1_val))
+    if (ABS(j0_val) > ABS(j1_val))
       cs = j0_val / f;
     else
       cs = j1_val / f2;
@@ -340,7 +340,7 @@ void bessel_find_jn_roots(int n, int num_roots, double* roots)
       double jn_val = bessel_jn(n, x), djndx_val = bessel_djndx(n, x);
       x -= jn_val/djndx_val;
     }
-    while (fabs(x-x0) > 1e-9);
+    while (ABS(x-x0) > 1e-9);
     roots[i] = x;
     x += M_PI + (0.0972 + 0.0679*n - 0.000354*n*n)/(i+1);
   }
@@ -363,7 +363,7 @@ double bessel_y0(double x)
       r0 *= -0.25*x2 / (k*k);
       double r = r0*w0;
       cs0 += r;
-      if (fabs(r) < 1e-15*fabs(cs0)) break;
+      if (ABS(r) < 1e-15*ABS(cs0)) break;
     }
     double j0_val = bessel_j0(x);
     val = jy_rp2 * (ec*j0_val - cs0);
@@ -406,7 +406,7 @@ double bessel_y1(double x)
       r1 *= -0.25*x2 / (k*(k+1));
       double r = r1 * (2.0*w1 + 1.0/(k+1));
       cs1 += r;
-      if (fabs(r) < 1e-15*fabs(cs1)) break;
+      if (ABS(r) < 1e-15*ABS(cs1)) break;
     }
     double j1_val = bessel_j1(x);
     val = jy_rp2 * (ec*j1_val - 1.0/x - 0.25*x*cs1);
@@ -497,7 +497,7 @@ void bessel_find_yn_roots(int n, int num_roots, double* roots)
       double yn_val = bessel_yn(n, x), dyndx_val = bessel_dyndx(n, x);
       x -= yn_val/dyndx_val;
     }
-    while (fabs(x-x0) > 1e-9);
+    while (ABS(x-x0) > 1e-9);
     roots[i] = x;
     x += M_PI + (0.312 + 0.0852*n - 0.000403*n*n)/(i+1);
   }

--- a/core/tests/test_declare_nd_array.c
+++ b/core/tests/test_declare_nd_array.c
@@ -138,7 +138,7 @@ static void test_int_array6(void** state)
 } 
 
 #define assert_real_equal(x, y) \
-  assert_true(fabs((real_t)x - y) < 1e-15)
+  assert_true(reals_nearly_equal((real_t)x, y, 1e-15))
 
 static void test_int_array7(void** state) 
 { 

--- a/core/tests/test_lookup1.c
+++ b/core/tests/test_lookup1.c
@@ -13,7 +13,7 @@
 #include "core/rng.h"
 #include "core/lookup1.h"
 
-#define assert_approx_equal(x, y, tol) assert_true(fabs((x) - (y)) < tol)
+#define assert_approx_equal(x, y, tol) assert_true(reals_nearly_equal((x), (y), tol))
 
 static void test_zero(void** state, lookup1_interpolation_t interpolation)
 {
@@ -91,7 +91,7 @@ static void test_v(void** state, lookup1_interpolation_t interpolation)
   // If we are using quadratic interpolation, we have to stay clear of the kink.
   if (interpolation == LOOKUP1_QUADRATIC) 
   {
-    while (fabs(x - 0.5) < dx)
+    while (ABS(x - 0.5) < dx)
       x = rng_uniform_positive(rng);
   }
 

--- a/core/tests/test_newton.c
+++ b/core/tests/test_newton.c
@@ -21,7 +21,7 @@ static void test_brent(void** state)
 {
   // Our cubic polynomial has a root x = 2 in the range [0, 10].
   double x = brent_solve(cubic_poly, NULL, 0.0, 10.0, 1e-12, 100);
-  assert_true(fabs(cubic_poly(NULL, x)) < 1e-12);
+  assert_true(reals_nearly_equal(cubic_poly(NULL, x), 0.0, 1e-12));
 }
 
 static int cubic_poly_1(void* context, real_t* x, real_t* F)
@@ -49,7 +49,7 @@ static void test_newton_solve_system_1(void** state)
   dense_newton_solver_free(solver);
 
   double F = (x + 1.0) * (x - 2.0) * (x + 3.0);
-  assert_true(fabs(F) < 1e-12);
+  assert_true(reals_nearly_equal(F, 0.0, 1e-12));
 }
 
 static void test_newton_solve_system_1_with_jacobian(void** state)
@@ -62,7 +62,7 @@ static void test_newton_solve_system_1_with_jacobian(void** state)
   dense_newton_solver_free(solver);
 
   double F = (x + 1.0) * (x - 2.0) * (x + 3.0);
-  assert_true(fabs(F) < 1e-12);
+  assert_true(reals_nearly_equal(F, 0.0, 1e-12));
 }
 
 static int circle_2(void* context, real_t* x, real_t* F)

--- a/core/tests/test_partition_mesh.c
+++ b/core/tests/test_partition_mesh.c
@@ -52,7 +52,7 @@ static void test_partition_linear_mesh(void** state)
   int cell_volumes_are_ok = 1;
   for (int c = 0; c < mesh->num_cells; ++c)
   {
-    if (fabs(mesh->cell_volumes[c] - dx*dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->cell_volumes[c], dx*dx*dx, 1e-12))
     {
       cell_volumes_are_ok = 0;
       break; 
@@ -61,7 +61,7 @@ static void test_partition_linear_mesh(void** state)
   int face_areas_are_ok = 1;
   for (int f = 0; f < mesh->num_faces; ++f)
   {
-    if (fabs(mesh->face_areas[f] - dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->face_areas[f], dx*dx, 1e-12))
     {
       face_areas_are_ok = 0;
       break; 
@@ -114,7 +114,7 @@ static void test_partition_slab_mesh(void** state)
   int cell_volumes_are_ok = 1;
   for (int c = 0; c < mesh->num_cells; ++c)
   {
-    if (fabs(mesh->cell_volumes[c] - dx*dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->cell_volumes[c], dx*dx*dx, 1e-12))
     {
       cell_volumes_are_ok = 0;
       break; 
@@ -123,7 +123,7 @@ static void test_partition_slab_mesh(void** state)
   int face_areas_are_ok = 1;
   for (int f = 0; f < mesh->num_faces; ++f)
   {
-    if (fabs(mesh->face_areas[f] - dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->face_areas[f], dx*dx, 1e-12))
     {
       face_areas_are_ok = 0;
       break; 
@@ -173,7 +173,7 @@ static void test_partition_box_mesh(void** state)
   int cell_volumes_are_ok = 1;
   for (int c = 0; c < mesh->num_cells; ++c)
   {
-    if (fabs(mesh->cell_volumes[c] - dx*dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->cell_volumes[c], dx*dx*dx, 1e-12))
     {
       cell_volumes_are_ok = 0;
       break; 
@@ -182,7 +182,7 @@ static void test_partition_box_mesh(void** state)
   int face_areas_are_ok = 1;
   for (int f = 0; f < mesh->num_faces; ++f)
   {
-    if (fabs(mesh->face_areas[f] - dx*dx) > 1e-12)
+    if (!reals_nearly_equal(mesh->face_areas[f], dx*dx, 1e-12))
     {
       face_areas_are_ok = 0;
       break; 

--- a/core/tests/test_partition_point_cloud.c
+++ b/core/tests/test_partition_point_cloud.c
@@ -41,9 +41,9 @@ static void test_partition_linear_cloud(void** state, int N)
     real_t y = cloud->points[i].y;
     real_t z = cloud->points[i].z;
     int j = (int)lround(x/dx - 0.5);
-    assert_true(fabs(x - (0.5+j)*dx) < 1e-6);
-    assert_true(fabs(y - 0.5) < 1e-6);
-    assert_true(fabs(z - 0.5) < 1e-6);
+    assert_true(reals_nearly_equal(x, (0.5+j)*dx, 1e-6));
+    assert_true(reals_nearly_equal(y, 0.5, 1e-6));
+    assert_true(reals_nearly_equal(z, 0.5, 1e-6));
   }
 
   // Plot it.

--- a/core/tests/test_polynomial.c
+++ b/core/tests/test_polynomial.c
@@ -135,7 +135,7 @@ static void test_basis(void** state, int p)
     while (polynomial_next(poly, &pos, &coeff, &x_pow, &y_pow, &z_pow))
     {
       real_t term = pow(x.x, x_pow) * pow(x.y, y_pow) * pow(x.z, z_pow);
-      assert_true(fabs(term - basis[index]) < 1e-14);
+      assert_true(reals_nearly_equal(term, basis[index], 1e-14));
       ++index;
     }
   }
@@ -158,7 +158,7 @@ static void test_basis(void** state, int p)
           real_t y_term = (y_pow >= j) ? pow(x.y, y_pow - j) * factorial(y_pow) / factorial(y_pow - j) : 0.0;
           real_t z_term = (z_pow >= k) ? pow(x.z, z_pow - k) * factorial(z_pow) / factorial(z_pow - k) : 0.0;
           real_t term = (i+j+k > p) ? 0.0 : x_term * y_term * z_term;
-          assert_true(fabs(term - basis_deriv[index]) < 1e-14);
+          assert_true(reals_nearly_equal(term, basis_deriv[index], 1e-14));
           ++index;
         }
       }

--- a/core/tests/test_special_functions.c
+++ b/core/tests/test_special_functions.c
@@ -29,7 +29,7 @@ static void test_bessel_find_jn_roots(void** state)
     bessel_find_jn_roots(n, 5, roots);
     for (int k = 0; k < 5; ++k)
     {
-      assert_true(fabs(roots[k] - jn_roots[n][k])/jn_roots[n][k] < 1e-4);
+      assert_true(ABS(roots[k] - jn_roots[n][k])/jn_roots[n][k] < 1e-4);
     }
   }
 }
@@ -42,7 +42,7 @@ static void test_bessel_jn(void** state, int n)
   double sign = -1.0;
   for (int i = 0; i < num_roots; ++i)
   {
-    assert_true(fabs(bessel_jn(n, roots[i])) < 1e-12);
+    assert_true(reals_nearly_equal(bessel_jn(n, roots[i]), 0.0, 1e-12));
     if (i < (num_roots-1))
     {
       assert_true(sign * bessel_jn(n, 0.5*(roots[i+1]+roots[i])) > 0.0);
@@ -93,7 +93,7 @@ static void test_bessel_find_yn_roots(void** state)
     bessel_find_yn_roots(n, 5, roots);
     for (int k = 0; k < 5; ++k)
     {
-      assert_true(fabs(roots[k] - yn_roots[n][k])/yn_roots[n][k] < 1e-4);
+      assert_true(ABS(roots[k] - yn_roots[n][k])/yn_roots[n][k] < 1e-4);
     }
   }
 }
@@ -106,7 +106,7 @@ static void test_bessel_yn(void** state, int n)
   double sign = 1.0;
   for (int i = 0; i < num_roots; ++i)
   {
-    assert_true(fabs(bessel_yn(n, roots[i])) < 1e-12);
+    assert_true(reals_nearly_equal(bessel_yn(n, roots[i]), 0.0, 1e-12));
     if (i < (num_roots-1))
     {
       assert_true(sign * bessel_yn(n, 0.5*(roots[i+1]+roots[i])) > 0.0);
@@ -145,17 +145,17 @@ static void test_hermite_hn(void** state)
   // Test the first 11 Hermite polynomials against those listed on 
   // Wikipedia.
   real_t x = 1.5; // an interesting point.
-  assert_true(fabs(hermite_hn(0, x) - (1.0)) < 1e-14);
-  assert_true(fabs(hermite_hn(1, x) - (2.0*x)) < 1e-14);
-  assert_true(fabs(hermite_hn(2, x) - (4.0*x*x-2.0)) < 1e-14);
-  assert_true(fabs(hermite_hn(3, x) - (8.0*pow(x, 3)-12.0*x)) < 1e-14);
-  assert_true(fabs(hermite_hn(4, x) - (16.0*pow(x, 4)-48.0*x*x+12.0)) < 1e-14);
-  assert_true(fabs(hermite_hn(5, x) - (32.0*pow(x, 5)-160.0*pow(x,3)+120.0*x)) < 1e-14);
-  assert_true(fabs(hermite_hn(6, x) - (64.0*pow(x, 6)-480.0*pow(x,4)+720.0*x*x-120.0)) < 1e-14);
-  assert_true(fabs(hermite_hn(7, x) - (128.0*pow(x, 7)-1344.0*pow(x, 5)+3360.0*pow(x,3)-1680.0*x)) < 1e-14);
-  assert_true(fabs(hermite_hn(8, x) - (256.0*pow(x, 8)-3584.0*pow(x, 6)+13440.0*pow(x,4)-13440.0*pow(x,2) + 1680.0)) < 1e-14);
-  assert_true(fabs(hermite_hn(9, x) - (512.0*pow(x, 9)-9216.0*pow(x, 7)+48384.0*pow(x,5)-80640.0*pow(x,3) + 30240.0*x)) < 1e-14);
-  assert_true(fabs(hermite_hn(10, x) - (1024.0*pow(x, 10)-23040.0*pow(x, 8)+161280.0*pow(x,6)-403200.0*pow(x,4) + 302400.0*x*x - 30240.0)) < 1e-14);
+  assert_true(reals_nearly_equal(hermite_hn(0, x), (1.0), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(1, x), (2.0*x), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(2, x), (4.0*x*x-2.0), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(3, x), (8.0*pow(x, 3)-12.0*x), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(4, x), (16.0*pow(x, 4)-48.0*x*x+12.0), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(5, x), (32.0*pow(x, 5)-160.0*pow(x,3)+120.0*x), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(6, x), (64.0*pow(x, 6)-480.0*pow(x,4)+720.0*x*x-120.0), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(7, x), (128.0*pow(x, 7)-1344.0*pow(x, 5)+3360.0*pow(x,3)-1680.0*x), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(8, x), (256.0*pow(x, 8)-3584.0*pow(x, 6)+13440.0*pow(x,4)-13440.0*pow(x,2) + 1680.0), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(9, x), (512.0*pow(x, 9)-9216.0*pow(x, 7)+48384.0*pow(x,5)-80640.0*pow(x,3) + 30240.0*x), 1e-14));
+  assert_true(reals_nearly_equal(hermite_hn(10, x), (1024.0*pow(x, 10)-23040.0*pow(x, 8)+161280.0*pow(x,6)-403200.0*pow(x,4) + 302400.0*x*x - 30240.0), 1e-14));
 }
 
 int main(int argc, char* argv[]) 

--- a/core/tests/test_tensor2.c
+++ b/core/tests/test_tensor2.c
@@ -13,7 +13,7 @@
 #include "core/polymec.h"
 #include "core/tensor2.h"
 
-#define assert_approx_equal(x, y, tol) assert_true(fabs(x - y) < tol)
+#define assert_approx_equal(x, y, tol) assert_true(reals_nearly_equal(x, y, tol))
 
 static void test_tensor2_ctor(void** state)
 {
@@ -245,9 +245,9 @@ static bool is_eigenvector(sym_tensor2_t* A, real_t lambda, vector_t* u)
 {
   vector_t Au;
   sym_tensor2_dot_vector(A, u, &Au);
-  return ((fabs(Au.x - lambda*u->x) < 1e-14) &&
-          (fabs(Au.y - lambda*u->y) < 1e-14) &&
-          (fabs(Au.z - lambda*u->z) < 1e-14));
+  return (reals_nearly_equal(Au.x, lambda*u->x, 1e-14) &&
+          reals_nearly_equal(Au.y, lambda*u->y, 1e-14) &&
+          reals_nearly_equal(Au.z, lambda*u->z, 1e-14));
 }
 
 static void test_sym_tensor2_get_eigenvectors(void** state)

--- a/geometry/create_rectilinear_mesh.c
+++ b/geometry/create_rectilinear_mesh.c
@@ -421,17 +421,17 @@ void tag_rectilinear_mesh_faces(mesh_t* mesh,
   {
     if (mesh->face_cells[2*f+1] == -1)
     {
-      if (fabs(mesh->face_centers[f].x - bbox->x1) < face_tol)
+      if (reals_nearly_equal(mesh->face_centers[f].x, bbox->x1, face_tol))
         int_slist_append(x1_faces, f);
-      else if (fabs(mesh->face_centers[f].x - bbox->x2) < face_tol)
+      else if (reals_nearly_equal(mesh->face_centers[f].x, bbox->x2, face_tol))
         int_slist_append(x2_faces, f);
-      if (fabs(mesh->face_centers[f].y - bbox->y1) < face_tol)
+      if (reals_nearly_equal(mesh->face_centers[f].y, bbox->y1, face_tol))
         int_slist_append(y1_faces, f);
-      else if (fabs(mesh->face_centers[f].y - bbox->y2) < face_tol)
+      else if (reals_nearly_equal(mesh->face_centers[f].y, bbox->y2, face_tol))
         int_slist_append(y2_faces, f);
-      if (fabs(mesh->face_centers[f].z - bbox->z1) < face_tol)
+      if (reals_nearly_equal(mesh->face_centers[f].z, bbox->z1, face_tol))
         int_slist_append(z1_faces, f);
-      else if (fabs(mesh->face_centers[f].z - bbox->z2) < face_tol)
+      else if (reals_nearly_equal(mesh->face_centers[f].z, bbox->z2, face_tol))
         int_slist_append(z2_faces, f);
     }
   }

--- a/geometry/cylinder_sp_func.c
+++ b/geometry/cylinder_sp_func.c
@@ -29,7 +29,7 @@ static void cyl_eval_gradient(void* ctx, point_t* x, real_t* result)
   cyl_t* c = ctx;
   real_t r2 = (x->x - c->x.x)*(x->x - c->x.x) + 
               (x->y - c->x.y)*(x->y - c->x.y);
-  real_t D = fabs(sqrt(r2) - c->r);
+  real_t D = ABS(sqrt(r2) - c->r);
   if (reals_equal(D, 0.0))
     result[0] = result[1] = result[2] = 0.0;
   else

--- a/integrators/euler_ode_integrator.c
+++ b/integrators/euler_ode_integrator.c
@@ -16,11 +16,11 @@ static real_t relative_difference(real_t x, real_t y)
     diff = 0.0;
   else if (reals_equal(x, 0.0) || reals_equal(y, 0.0))
   {
-    real_t ref_value = MAX(fabs(x), fabs(y));
-    diff = fabs((x - y)/ref_value);
+    real_t ref_value = MAX(ABS(x), ABS(y));
+    diff = ABS((x - y)/ref_value);
   }
   else
-    diff = fabs((x - y)/x);
+    diff = ABS((x - y)/x);
   return diff;
 }
 
@@ -37,7 +37,7 @@ static void compute_l1_norms(MPI_Comm comm,
   {
     real_t xi = x[i], yi = y[i];
     real_t rel_diff = relative_difference(xi, yi);
-    real_t abs_diff = fabs(xi-yi);
+    real_t abs_diff = ABS(xi-yi);
     rel += rel_diff;
     abs += abs_diff;
   }
@@ -61,7 +61,7 @@ static void compute_l2_norms(MPI_Comm comm,
   {
     real_t xi = x[i], yi = y[i];
     real_t rel_diff = relative_difference(xi, yi);
-    real_t abs_diff = fabs(xi-yi);
+    real_t abs_diff = ABS(xi-yi);
     rel += rel_diff*rel_diff;
     abs += abs_diff*abs_diff;
   }
@@ -85,7 +85,7 @@ static void compute_linf_norms(MPI_Comm comm,
   {
     real_t xi = x[i], yi = y[i];
     real_t rel_diff = relative_difference(xi, yi);
-    real_t abs_diff = fabs(xi-yi);
+    real_t abs_diff = ABS(xi-yi);
     rel = MAX(rel, rel_diff);
     abs = MAX(abs, abs_diff);
   }

--- a/integrators/gauss_rules.c
+++ b/integrators/gauss_rules.c
@@ -36,7 +36,7 @@ void get_gauss_points(int n, real_t* points, real_t* weights)
 
       pp = m * (z*p1-p2) / (z*z - 1);
 
-      if (fabs(p1/pp) < 2e-16) break;
+      if (ABS(p1/pp) < 2e-16) break;
 
       z = z - p1/pp;
     }
@@ -190,7 +190,7 @@ void get_gauss_lobatto_points(int n, real_t* points, real_t* weights)
           }
         }
 
-        if (fabs(d0/s0) < 2e-16) break;
+        if (ABS(d0/s0) < 2e-16) break;
         ++k;
         ASSERT(k < 6);
 

--- a/integrators/krylov_newton_pc.c
+++ b/integrators/krylov_newton_pc.c
@@ -186,7 +186,7 @@ static int Atimes_DQ_adaptor(void* A_data, N_Vector v, N_Vector Av)
   real_t sq1norm = N_VL1Norm(krylov->temp1);
   real_t sign = SIGN(sutsv);
   real_t sqrt_relfunc = sqrt(UNIT_ROUNDOFF);
-  real_t sigma = sign * sqrt_relfunc * MAX(fabs(sutsv), sq1norm) / vtv;
+  real_t sigma = sign * sqrt_relfunc * MAX(ABS(sutsv), sq1norm) / vtv;
   real_t sigma_inv = 1.0 / sigma;
 
   // Add the identity term into Av.

--- a/integrators/sphere_integrator.c
+++ b/integrators/sphere_integrator.c
@@ -347,7 +347,7 @@ static void eval_F_o_n(void* context, point_t* x, real_t* F_o_n)
   vector_t n = {.x = cos(phi) * sin(theta), 
                 .y = sin(phi) * sin(theta),
                 .z = cos(theta)};
-  ASSERT(fabs(vector_mag(&n) - 1.0) < 1e-12);
+  ASSERT(reals_nearly_equal(vector_mag(&n), 1.0, 1e-12));
 
   // Compute the polynomial vector F at the point x.
   vector_t F = {.x = polynomial_value(Fr->Fx, x),

--- a/integrators/tests/test_div_free_poly_basis.c
+++ b/integrators/tests/test_div_free_poly_basis.c
@@ -75,7 +75,7 @@ static void test_divergence(void** state)
 //      printf("   ");
 //      polynomial_fprintf(z, stdout);
 //      printf(" div f%d = %g\n", pos, divf);
-      assert_true(fabs(divf) < 1e-14);
+      assert_true(reals_nearly_equal(divf, 0.0, 1e-14));
     }
     basis = NULL;
   }

--- a/integrators/tests/test_euler_ode_integrator.c
+++ b/integrators/tests/test_euler_ode_integrator.c
@@ -69,7 +69,7 @@ static void test_symplectic_central_force(void** state)
 
     // Check energy conservation.
     real_t E = 0.5 * (X[2]*X[2] + X[3]*X[3]);
-    assert_true(fabs(E - 0.5) < 1e-3);
+    assert_true(reals_nearly_equal(E, 0.5, 1e-3));
 
     // Compute error norms.
     real_t L2 = sqrt((X[0]-R)*(X[0]-R) + X[1]*X[1] + X[2]*X[2] + (X[3]-V)*(X[3]-V));

--- a/integrators/tests/test_midpoint_polyhedron_integrator.c
+++ b/integrators/tests/test_midpoint_polyhedron_integrator.c
@@ -100,13 +100,13 @@ static void test_cube_volume_integrals(void** state)
 {
   polyhedron_integrator_t* I = midpoint_polyhedron_integrator_new();
   real_t I1_1 = cube_volume_integral(I, 1.0, f1);
-  assert_true(fabs(I1_1 - 0.5) < 1e-14);
+  assert_true(reals_nearly_equal(I1_1, 0.5, 1e-14));
   real_t I1_2 = cube_volume_integral(I, 0.5, f1);
-  assert_true(fabs(I1_2 - 0.03125) < 1e-14);
+  assert_true(reals_nearly_equal(I1_2, 0.03125, 1e-14));
   real_t I2_1 = cube_volume_integral(I, 1.0, f2);
-  assert_true(fabs(I2_1 - 0.75) < 1e-14);
+  assert_true(reals_nearly_equal(I2_1, 0.75, 1e-14));
   real_t I2_2 = cube_volume_integral(I, 0.5, f2);
-  assert_true(fabs(I2_2 - 0.0390625) < 1e-14);
+  assert_true(reals_nearly_equal(I2_2, 0.0390625, 1e-14));
   polyhedron_integrator_free(I);
 }
 
@@ -114,13 +114,13 @@ static void test_cube_surface_integrals(void** state)
 {
   polyhedron_integrator_t* I = midpoint_polyhedron_integrator_new();
   real_t I1_1 = cube_surface_integral(I, 1.0, g1);
-  assert_true(fabs(I1_1 - 1.0) < 1e-14);
+  assert_true(reals_nearly_equal(I1_1, 1.0, 1e-14));
   real_t I1_2 = cube_surface_integral(I, 0.5, g1);
-  assert_true(fabs(I1_2 - 0.125) < 1e-14);
+  assert_true(reals_nearly_equal(I1_2, 0.125, 1e-14));
   real_t I2_1 = cube_surface_integral(I, 1.0, g2);
-  assert_true(fabs(I2_1 - 2.0) < 1e-14);
+  assert_true(reals_nearly_equal(I2_1, 2.0, 1e-14));
   real_t I2_2 = cube_surface_integral(I, 0.5, g2);
-  assert_true(fabs(I2_2 - 0.1875) < 1e-14);
+  assert_true(reals_nearly_equal(I2_2, 0.1875, 1e-14));
   polyhedron_integrator_free(I);
 }
 

--- a/integrators/tests/test_sphere_integrator.c
+++ b/integrators/tests/test_sphere_integrator.c
@@ -41,15 +41,15 @@ void test_cap_area(void** state)
       // This should give zero.
       real_t area;
       sphere_integrator_cap(I, &x0, radius, one, &e3, 0.0, &area);
-      assert_true(fabs(area) < 1e-12);
+      assert_true(reals_nearly_equal(area, 0.0, 1e-12));
 
       // This should give the area of the entire sphere.
       sphere_integrator_cap(I, &x0, radius, one, &e3, M_PI, &area);
-      assert_true(fabs(area - 4.0*M_PI*radius*radius) < 1e-12);
+      assert_true(reals_nearly_equal(area, 4.0*M_PI*radius*radius, 1e-12));
 
       // This should give half the area of the sphere.
       sphere_integrator_cap(I, &x0, radius, one, &e3, 0.5*M_PI, &area);
-      assert_true(fabs(area - 2.0*M_PI*radius*radius) < 1e-12);
+      assert_true(reals_nearly_equal(area, 2.0*M_PI*radius*radius, 1e-12));
     }
 
     sphere_integrator_free(I);
@@ -95,7 +95,7 @@ static void test_cap_radial_function(void** state,
 
   real_t result;
   sphere_integrator_cap(I, &x0, radius, f, &e3, gamma, &result);
-  assert_true(fabs(result - answer) < 1e-12);
+  assert_true(reals_nearly_equal(result, answer, 1e-12));
 
   sphere_integrator_free(I);
 }
@@ -182,7 +182,7 @@ static void test_cap_time_dep_radial_function(void** state,
 
   real_t result;
   sphere_integrator_cap_at_time(I, &x0, radius, f, &e3, gamma, t, &result);
-  assert_true(fabs(result - answer) < tolerance);
+  assert_true(reals_nearly_equal(result, answer, tolerance));
 
   sphere_integrator_free(I);
 }

--- a/model/model.c
+++ b/model/model.c
@@ -656,7 +656,7 @@ static void model_do_periodic_work(model_t* model)
   if (model->plot_every > 0.0)
   {
     int n = (int)(model->time / model->plot_every);
-    if (fabs(model->time - n * model->plot_every) < 1e-12) // FIXME: cheesy...
+    if (reals_nearly_equal(model->time, n * model->plot_every, 1e-12)) // FIXME: cheesy...
       model_plot(model);
   }
 
@@ -672,7 +672,7 @@ static void model_do_periodic_work(model_t* model)
   {
     int obs_time_index = real_lower_bound(model->obs_times, model->num_obs_times, model->time);
     if ((obs_time_index < model->num_obs_times) && 
-        (fabs(model->time - model->obs_times[obs_time_index]) < 1e-12)) // FIXME: Good enough?
+        (reals_nearly_equal(model->time, model->obs_times[obs_time_index], 1e-12))) // FIXME: Good enough?
       model_record_observations(model);
   }
 }

--- a/model/tests/test_interpreter.c
+++ b/model/tests/test_interpreter.c
@@ -50,7 +50,7 @@ static void test_interpreter_with_long_string(void** state)
   point_t x;
   double t = 0.0, five;
   st_func_eval(f, &x, t, &five);
-  assert_true(fabs(five - 5.0) < 1e-15);
+  assert_true(reals_equal(five, 5.0));
 
   assert_true(interpreter_contains(interp, "F", INTERPRETER_VECTOR_FUNCTION));
   assert_true(interpreter_get_vector_function(interp, "F") != NULL);
@@ -65,9 +65,9 @@ static void test_interpreter_with_long_string(void** state)
   assert_true(st_func_is_constant(F));
   double one_two_three[3];
   st_func_eval(F, &x, t, one_two_three);
-  assert_true(fabs(one_two_three[0] - 1.0) < 1e-15);
-  assert_true(fabs(one_two_three[1] - 2.0) < 1e-15);
-  assert_true(fabs(one_two_three[2] - 3.0) < 1e-15);
+  assert_true(reals_equal(one_two_three[0], 1.0));
+  assert_true(reals_equal(one_two_three[1], 2.0));
+  assert_true(reals_equal(one_two_three[2], 3.0));
 
   assert_true(interpreter_contains(interp, "V", INTERPRETER_VECTOR_FUNCTION));
   assert_true(interpreter_get_vector_function(interp, "V") != NULL);
@@ -76,9 +76,9 @@ static void test_interpreter_with_long_string(void** state)
   assert_true(st_func_is_homogeneous(V));
   assert_true(st_func_is_constant(V));
   st_func_eval(V, &x, t, one_two_three);
-  assert_true(fabs(one_two_three[0] - 1.0) < 1e-15);
-  assert_true(fabs(one_two_three[1] - 2.0) < 1e-15);
-  assert_true(fabs(one_two_three[2] - 3.0) < 1e-15);
+  assert_true(reals_equal(one_two_three[0], 1.0));
+  assert_true(reals_equal(one_two_three[1], 2.0));
+  assert_true(reals_equal(one_two_three[2], 3.0));
 
   assert_true(interpreter_contains(interp, "Z", INTERPRETER_SCALAR_FUNCTION));
   assert_true(interpreter_get_scalar_function(interp, "Z") != NULL);
@@ -96,7 +96,7 @@ static void test_interpreter_with_long_string(void** state)
   real_t answer;
   st_func_eval(Z, &x, t, &answer);
   printf("Z = %g\n", answer);
-  assert_true(fabs(answer - sqrt(10.0)) < 1e-15);
+  assert_true(reals_nearly_equal(answer, sqrt(10.0), 1e-15));
 
   assert_true(interpreter_contains(interp, "g", INTERPRETER_NUMBER));
   assert_true((int)(interpreter_get_number(interp, "g")) == 2);
@@ -124,9 +124,9 @@ static void test_point_parsing(void** state)
   assert_true(interpreter_get_point(interp, "p") != NULL);
   assert_true(interpreter_get_point(interp, "q") == NULL);
   point_t* p = interpreter_get_point(interp, "p");
-  assert_true(fabs(p->x - 1.0) < 1e-15);
-  assert_true(fabs(p->y - 2.0) < 1e-15);
-  assert_true(fabs(p->z - 3.0) < 1e-15);
+  assert_true(reals_equal(p->x, 1.0));
+  assert_true(reals_equal(p->y, 2.0));
+  assert_true(reals_equal(p->z, 3.0));
   interpreter_free(interp);
 }
 
@@ -143,9 +143,9 @@ static void test_vector_parsing(void** state)
   assert_true(interpreter_get_vector(interp, "v") != NULL);
   assert_true(interpreter_get_vector(interp, "w") == NULL);
   vector_t* v = interpreter_get_vector(interp, "v");
-  assert_true(fabs(v->x - 1.0) < 1e-15);
-  assert_true(fabs(v->y - 2.0) < 1e-15);
-  assert_true(fabs(v->z - 3.0) < 1e-15);
+  assert_true(reals_equal(v->x, 1.0));
+  assert_true(reals_equal(v->y, 2.0));
+  assert_true(reals_equal(v->z, 3.0));
   interpreter_free(interp);
 }
 
@@ -162,12 +162,12 @@ static void test_boundingbox_parsing(void** state)
   assert_true(interpreter_get_bbox(interp, "b") != NULL);
   assert_true(interpreter_get_bbox(interp, "c") == NULL);
   bbox_t* b = interpreter_get_bbox(interp, "b");
-  assert_true(fabs(b->x1 - 0.0) < 1e-15);
-  assert_true(fabs(b->x2 - 1.0) < 1e-15);
-  assert_true(fabs(b->y1 - 0.0) < 1e-15);
-  assert_true(fabs(b->y2 - 1.0) < 1e-15);
-  assert_true(fabs(b->z1 - 0.0) < 1e-15);
-  assert_true(fabs(b->z2 - 1.0) < 1e-15);
+  assert_true(reals_equal(b->x1, 0.0));
+  assert_true(reals_equal(b->x2, 1.0));
+  assert_true(reals_equal(b->y1, 0.0));
+  assert_true(reals_equal(b->y2, 1.0));
+  assert_true(reals_equal(b->z1, 0.0));
+  assert_true(reals_equal(b->z2, 1.0));
   interpreter_free(interp);
 }
 
@@ -231,9 +231,9 @@ static void test_vectorlist_parsing(void** state)
                                  {.x = 1.0, .y = 1.0, .z = 1.0}};
   for (int i = 0; i < 8; ++i)
   {
-    assert_true(fabs(vecs[i].x - real_vecs[i].x) < 1e-15);
-    assert_true(fabs(vecs[i].y - real_vecs[i].y) < 1e-15);
-    assert_true(fabs(vecs[i].z - real_vecs[i].z) < 1e-15);
+    assert_true(reals_equal(vecs[i].x, real_vecs[i].x));
+    assert_true(reals_equal(vecs[i].y, real_vecs[i].y));
+    assert_true(reals_equal(vecs[i].z, real_vecs[i].z));
   }
   polymec_free(vecs);
   interpreter_free(interp);
@@ -285,7 +285,7 @@ static void test_scalarfunction_parsing(void** state)
     assert_true(f != NULL);
     assert_true(st_func_num_comp(f) == 1);
     st_func_eval(f, &x, t, &val);
-    assert_true(fabs(val - 1.0) < 1e-15);
+    assert_true(reals_equal(val, 1.0));
     interpreter_free(interp);
   }
 
@@ -302,7 +302,7 @@ static void test_scalarfunction_parsing(void** state)
     assert_true(f != NULL);
     assert_true(st_func_num_comp(f) == 1);
     st_func_eval(f, &x, t, &val);
-    assert_true(fabs(val - 1.0) < 1e-15);
+    assert_true(reals_equal(val, 1.0));
     interpreter_free(interp);
   }
 
@@ -322,7 +322,7 @@ static void test_scalarfunction_parsing(void** state)
     assert_true(f != NULL);
     assert_true(st_func_num_comp(f) == 1);
     st_func_eval(f, &x, t, &val);
-    assert_true(fabs(val - sqrt(13.0)) < 1e-15);
+    assert_true(reals_nearly_equal(val, sqrt(13.0), 1e-15));
     interpreter_free(interp);
   }
 }

--- a/model/tests/test_partition_point_cloud_with_neighbors.c
+++ b/model/tests/test_partition_point_cloud_with_neighbors.c
@@ -48,9 +48,9 @@ static void test_partition_linear_cloud(void** state, int N)
     real_t y = cloud->points[i].y;
     real_t z = cloud->points[i].z;
     int j = (int)lround(x/dx - 0.5);
-    assert_true(fabs(x - (0.5+j)*dx) < 1e-6);
-    assert_true(fabs(y - 0.5) < 1e-6);
-    assert_true(fabs(z - 0.5) < 1e-6);
+    assert_true(reals_nearly_equal(x, (0.5+j)*dx, 1e-6));
+    assert_true(reals_nearly_equal(y, 0.5, 1e-6));
+    assert_true(reals_nearly_equal(z, 0.5, 1e-6));
   }
 
   // Plot it.
@@ -107,9 +107,9 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
     real_t y = cloud->points[i].y;
     real_t z = cloud->points[i].z;
     int j = lround(x/dx - 0.5);
-    assert_true(fabs(x - (0.5+j)*dx) < 1e-6);
-    assert_true(fabs(y) < 1e-6);
-    assert_true(fabs(z) < 1e-6);
+    assert_true(reals_nearly_equal(x, (0.5+j)*dx, 1e-6));
+    assert_true(reals_nearly_equal(y, 0.0, 1e-6));
+    assert_true(reals_nearly_equal(z, 0.0, 1e-6));
   }
 #endif
 
@@ -167,9 +167,9 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
     real_t y = cloud->points[i].y;
     real_t z = cloud->points[i].z;
     int j = lround(x/dx - 0.5);
-    assert_true(fabs(x - (0.5+j)*dx) < 1e-6);
-    assert_true(fabs(y) < 1e-6);
-    assert_true(fabs(z) < 1e-6);
+    assert_true(reals_nearly_equal(x, (0.5+j)*dx, 1e-6));
+    assert_true(reals_nearly_equal(y, 0.0, 1e-6));
+    assert_true(reals_nearly_equal(z, 0.0, 1e-6));
   }
 #endif
 

--- a/model/tests/test_polynomial_fit.c
+++ b/model/tests/test_polynomial_fit.c
@@ -60,14 +60,14 @@ static void test_fit_consistency(void** state, polynomial_fit_t* fit, int compon
     polynomial_fit_eval_deriv(fit, 0, 1, 0, &xrand, dudy);
     polynomial_fit_eval_deriv(fit, 0, 0, 1, &xrand, dudz);
 
-//printf("u error: %g-%g=%g\n", u[component], q, fabs(u[component]-q));
-//printf("dudx error: %g\n", fabs(dudx[component]-dqdx));
-//printf("dudy error: %g\n", fabs(dudy[component]-dqdy));
-//printf("dudz error: %g\n", fabs(dudz[component]-dqdz));
-    assert_true(fabs(u[component] - q) < 5e-14);
-    assert_true(fabs(dudx[component] - dqdx) < 5e-14);
-    assert_true(fabs(dudy[component] - dqdy) < 5e-14);
-    assert_true(fabs(dudz[component] - dqdz) < 5e-14);
+//printf("u error: |%g-%g|=%g\n", u[component], q, ABS(u[component]-q));
+//printf("dudx error: %g\n", ABS(dudx[component]-dqdx));
+//printf("dudy error: %g\n", ABS(dudy[component]-dqdy));
+//printf("dudz error: %g\n", ABS(dudz[component]-dqdz));
+    assert_true(reals_nearly_equal(u[component], q, 5e-14));
+    assert_true(reals_nearly_equal(dudx[component], dqdx, 5e-14));
+    assert_true(reals_nearly_equal(dudy[component], dqdy, 5e-14));
+    assert_true(reals_nearly_equal(dudz[component], dqdz, 5e-14));
   }
 }
 

--- a/model/tests/test_shepard_point_basis.c
+++ b/model/tests/test_shepard_point_basis.c
@@ -119,7 +119,7 @@ static void test_shepard_point_basis_consistency(void** state)
       ++k;
     }
 
-    assert_true(fabs(val - 1.0) < 1e-14);
+    assert_true(reals_nearly_equal(val, 1.0, 1e-14));
   }
 
   // Clean up.


### PR DESCRIPTION
* Added some more compiler warning suppressants.
* Eliminated fabs() calls from the code, using reals_equal() and reals_nearly_equal() instead.
* Changed a call to gethostname() to a call to MPI_Get_process_name().