### PR TITLE
Eliminated deprecated exchanger/migrator functions.

### DIFF
--- a/core/exchanger.c
+++ b/core/exchanger.c
@@ -363,11 +363,6 @@ exchanger_t* exchanger_new(MPI_Comm comm)
   return exchanger_new_with_rank(comm, rank);
 }
 
-void exchanger_free(exchanger_t* ex)
-{
-  POLYMEC_DEPRECATED
-}
-
 exchanger_t* exchanger_clone(exchanger_t* ex)
 {
   exchanger_t* clone = exchanger_new(ex->comm);
@@ -1215,11 +1210,6 @@ migrator_t* migrator_new(MPI_Comm comm)
   return m;
 }
 
-void migrator_free(migrator_t* m)
-{
-  POLYMEC_DEPRECATED
-}
-
 migrator_t* migrator_clone(migrator_t* m)
 {
   migrator_t* clone = GC_MALLOC(sizeof(migrator_t));
@@ -1517,62 +1507,6 @@ static void m_write(void* obj, byte_array_t* bytes, size_t* offset)
 
 serializer_t* migrator_serializer()
 {
-  return serializer_new("migrator", m_size, m_read, m_write, DTOR(migrator_free));
+  return serializer_new("migrator", m_size, m_read, m_write, NULL);
 }
 
-// Backwards-compatible deprecated functions.
-void exchanger_transfer(exchanger_t* ex, void* data, int* count, int stride, int tag, MPI_Datatype type)
-{
-  POLYMEC_DEPRECATED
-  migrator_t m;
-  m.ex = ex;
-  migrator_transfer(&m, data, count, stride, tag, type);
-}
-
-int exchanger_start_transfer(exchanger_t* ex, void* data, int* count, int stride, int tag, MPI_Datatype type)
-{
-  POLYMEC_DEPRECATED
-  migrator_t m;
-  m.ex = ex;
-  return migrator_start_transfer(&m, data, count, stride, tag, type);
-}
-
-void exchanger_finish_transfer(exchanger_t* ex, int token)
-{
-  POLYMEC_DEPRECATED
-  migrator_t m;
-  m.ex = ex;
-  migrator_finish_transfer(&m, token);
-}
-
-exchanger_t* create_distributor(MPI_Comm comm, 
-                                int64_t* global_partition,
-                                int num_global_vertices)
-{
-  POLYMEC_DEPRECATED
-  migrator_t* m = migrator_from_global_partition(comm, 
-                                                 global_partition, 
-                                                 num_global_vertices);
-  exchanger_t* ex = m->ex;
-  polymec_free(m);
-  return ex;
-}
-
-exchanger_t* create_migrator(MPI_Comm comm,
-                             int64_t* local_partition,
-                             int num_local_vertices)
-{
-  POLYMEC_DEPRECATED
-  migrator_t* m = migrator_from_local_partition(comm, 
-                                                local_partition, 
-                                                num_local_vertices);
-  exchanger_t* ex = m->ex;
-  polymec_free(m);
-  return ex;
-}
-
-exchanger_t* migrator_exchanger(migrator_t* m)
-{
-  POLYMEC_DEPRECATED
-  return m->ex;
-}

--- a/core/exchanger.h
+++ b/core/exchanger.h
@@ -22,10 +22,6 @@ exchanger_t* exchanger_new(MPI_Comm comm);
 // Constructs a new exchanger on the given communicator with the given rank.
 exchanger_t* exchanger_new_with_rank(MPI_Comm comm, int rank);
 
-// Destroys an exchanger.
-// This function is deprecated.
-void exchanger_free(exchanger_t* ex);
-
 // Creates a complete copy of the given exchanger.
 exchanger_t* exchanger_clone(exchanger_t* ex);
 
@@ -237,10 +233,6 @@ migrator_t* migrator_from_local_partition(MPI_Comm comm,
                                           int64_t* local_partition,
                                           int num_local_vertices);
 
-// Destroys a migrator.
-// This function is deprecated.
-void migrator_free(migrator_t* m);
-
 // Creates a complete copy of the given migrator.
 migrator_t* migrator_clone(migrator_t* m);
 
@@ -283,26 +275,5 @@ void migrator_fprintf(migrator_t* m, FILE* stream);
 
 // This creates a serializer object that can read and write migrators to byte streams.
 serializer_t* migrator_serializer(void);
-
-//------------------------------------------------------------------------
-
-// The following functions preceded the separation of the migrator type from 
-// the exchanger type and are provided for backwards compatibility, but 
-// are deprecated. Please use the migrator transfer functions instead.
-void exchanger_transfer(exchanger_t* ex, void* data, int* count, int stride, int tag, MPI_Datatype type);
-int exchanger_start_transfer(exchanger_t* ex, void* data, int* count, int stride, int tag, MPI_Datatype type);
-void exchanger_finish_transfer(exchanger_t* ex, int token);
-
-exchanger_t* create_distributor(MPI_Comm comm, 
-                                int64_t* global_partition,
-                                int num_global_vertices);
-
-exchanger_t* create_migrator(MPI_Comm comm,
-                             int64_t* local_partition,
-                             int num_local_vertices);
-
-// Provided to extract the underlying exchanger from a migrator, again for 
-// backward compatibility.
-exchanger_t* migrator_exchanger(migrator_t* m);
 
 #endif


### PR DESCRIPTION
* Destructors are no longer needed, as these types are garbage-collected.
* The migrator/exchanger relationship is no longer expressed as part of the
  API.

Fixes #158 