### PR TITLE
Introduced a garbage collection interface.

### DIFF
--- a/core/allocators.c
+++ b/core/allocators.c
@@ -78,7 +78,7 @@ static void* std_malloc(void* context, size_t size)
 {
   // We want to trace pointers within this memory, so we need to use the 
   // garbage collector's allocator.
-  return GC_malloc_uncollectable(size);
+  return GC_MALLOC_UNCOLLECTABLE(size);
 }
 
 static void* std_aligned_alloc(void* context, size_t alignment, size_t size)
@@ -88,7 +88,8 @@ static void* std_aligned_alloc(void* context, size_t alignment, size_t size)
   polymec_error("Aligned allocations are not available on MacOS/Intel at this time.");
   return NULL;
 #else
-  return aligned_alloc(alignment, size);
+  polymec_error("Aligned allocations are supported by the standard allocator.");
+  return NULL;
 #endif
 }
 

--- a/core/allocators.h
+++ b/core/allocators.h
@@ -32,6 +32,10 @@ typedef struct
   // This might not be available on every allocator.
   void* (*aligned_realloc)(void* context, void* memory, size_t alignment, size_t size);
 
+  // Allocates a traced chunk of memory that is garbage-collected. Also takes 
+  // a destructor that is called on the freed memory.
+  void* (*gc_malloc)(void* context, size_t size, void (*dtor)(void* context));
+
   // Frees the given chunk of memory.
   void (*free)(void* context, void* memory);
   
@@ -70,6 +74,16 @@ void* polymec_realloc(void* memory, size_t size);
 // If the stack is empty, a fatal error is issued, since there is no 
 // portable way to perform an aligned realloc with the standard C allocator.
 void* polymec_aligned_realloc(void* memory, size_t alignment, size_t size);
+
+// This version of polymec_malloc returns memory that will be garbage-collected.
+// It should not be freed. It is appropriate for objects that are shared by 
+// many systems, and that don't consume large amounts of resources. It includes
+// a destructor that is called on the returned pointer when the memory is 
+// collected.
+// NOTE: There is no garbage-collected realloc (polymec_gc_realloc), since we 
+// NOTE: don't want to encourage the use of garbage collection for 
+// NOTE: data-intensive objects.
+void* polymec_gc_malloc(size_t size, void (*dtor)(void* memory));
 
 // Frees memory, returning it to the allocator on top of the allocator stack 
 // (or calling free() if the stack is empty).

--- a/core/arch.c
+++ b/core/arch.c
@@ -76,7 +76,7 @@ static int fmem_close(void *context)
 
 FILE *fmemopen(void *buf, size_t size, const char *mode) 
 {
-  fmem_t* fmem = polymec_malloc(sizeof(fmem_t)); // Context pointer.
+  fmem_t* fmem = malloc(sizeof(fmem_t)); // Context pointer.
   fmem->pos = 0;
   fmem->size = size;
   fmem->buffer = buf;
@@ -111,7 +111,7 @@ static int memstream_write(void* context, const char *buf, int n)
     size_t newsize = stream->allocated * 3 / 2;
     if (newsize < stream->pos + n + 1)
       newsize = stream->pos + n + 1;
-    cbuf = polymec_realloc(cbuf, newsize);
+    cbuf = realloc(cbuf, newsize);
     if (!cbuf)
       return EOF;
     *stream->buf = cbuf;
@@ -179,7 +179,7 @@ static int memstream_close(void *c)
   memstream_t *stream = c;
   char *buf;
 
-  buf = polymec_realloc(*stream->buf, *stream->len + 1);
+  buf = realloc(*stream->buf, *stream->len + 1);
   if (buf != NULL)
     *stream->buf = buf;
   polymec_free(stream);
@@ -197,7 +197,7 @@ FILE* open_memstream(char **buf, size_t *len)
     return NULL;
   }
   stream = polymec_malloc(sizeof(memstream_t));
-  *buf = polymec_malloc(32 * sizeof(char));
+  *buf = malloc(32 * sizeof(char));
   **buf = '\0';
   *len = 0;
 

--- a/core/hilbert.c
+++ b/core/hilbert.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/hilbert.h"
 
 struct hilbert_t 
@@ -22,7 +21,7 @@ static const int num_bits = 16;
 hilbert_t* hilbert_new(bbox_t* bbox)
 {
   int num_bins = 1 << num_bits;
-  hilbert_t* curve = GC_MALLOC(sizeof(hilbert_t));
+  hilbert_t* curve = polymec_gc_malloc(sizeof(hilbert_t), NULL);
   curve->bbox = *bbox;
   curve->dx = (bbox->x2 - bbox->x1) / (num_bins-1);
   curve->dy = (bbox->y2 - bbox->y1) / (num_bins-1);

--- a/core/least_squares.c
+++ b/core/least_squares.c
@@ -7,7 +7,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <gc/gc.h>
 #include "core/polymec.h"
 #include "core/least_squares.h"
 #include "core/polynomial.h"
@@ -55,7 +54,7 @@ struct ls_weight_func_t
   point_t x0;
 };
 
-static void ls_weight_func_free(void* context, void* dummy)
+static void ls_weight_func_free(void* context)
 {
   ls_weight_func_t* W = context;
   if ((W->context != NULL) && (W->vtable.dtor != NULL))
@@ -69,12 +68,11 @@ ls_weight_func_t* ls_weight_func_new(const char* name,
 {
   ASSERT(vtable.eval != NULL);
 
-  ls_weight_func_t* W = GC_MALLOC(sizeof(ls_weight_func_t));
+  ls_weight_func_t* W = polymec_gc_malloc(sizeof(ls_weight_func_t), ls_weight_func_free);
   W->name = string_dup(name);
   W->context = context;
   W->vtable = vtable;
   W->x0.x = W->x0.y = W->x0.z = 0.0;
-  GC_register_finalizer(W, &ls_weight_func_free, W, NULL, NULL);
   return W;
 }
 

--- a/core/options.c
+++ b/core/options.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/polymec.h"
 #include "core/options.h"
 #include "core/unordered_map.h"
@@ -20,7 +19,7 @@ struct options_t
 // Options argv singleton.
 static options_t* argv_singleton = NULL;
 
-static void options_free(void* ctx, void* dummy)
+static void options_free(void* ctx)
 {
   options_t* opts = (options_t*)ctx;
 
@@ -40,11 +39,10 @@ static void destroy_kv(char* key, char* value)
 
 options_t* options_new(void)
 {
-  options_t* o = GC_MALLOC(sizeof(options_t));
+  options_t* o = polymec_gc_malloc(sizeof(options_t), options_free);
   o->num_args = 0;
   o->args = NULL;
   o->params = string_string_unordered_map_new();
-  GC_register_finalizer(o, &options_free, o, NULL, NULL);
   return o;
 }
 

--- a/core/point.c
+++ b/core/point.c
@@ -5,12 +5,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/point.h"
 
 point_t* point_new(real_t x, real_t y, real_t z)
 {
-  point_t* p = GC_MALLOC(sizeof(point_t));
+  point_t* p = polymec_gc_malloc(sizeof(point_t), NULL);
   p->x = x, p->y = y, p->z = z;
   return p;
 }
@@ -22,7 +21,7 @@ void point_fprintf(point_t* x, FILE* stream)
 
 vector_t* vector_new(real_t vx, real_t vy, real_t vz)
 {
-  vector_t* v = GC_MALLOC(sizeof(vector_t));
+  vector_t* v = polymec_gc_malloc(sizeof(vector_t), NULL);
   v->x = vx, v->y = vy, v->z = vz;
   return v;
 }
@@ -32,7 +31,7 @@ bbox_t* bbox_new(real_t x1, real_t x2, real_t y1, real_t y2, real_t z1, real_t z
   ASSERT(x1 < x2);
   ASSERT(y1 < y2);
   ASSERT(z1 < z2);
-  bbox_t* b = GC_MALLOC(sizeof(bbox_t));
+  bbox_t* b = polymec_gc_malloc(sizeof(bbox_t), NULL);
   b->x1 = x1;
   b->x2 = x2;
   b->y1 = y1;
@@ -49,7 +48,7 @@ bbox_t* bbox_clone(bbox_t* box)
 
 bbox_t* empty_set_bbox_new()
 {
-  bbox_t* b = GC_MALLOC(sizeof(bbox_t));
+  bbox_t* b = polymec_gc_malloc(sizeof(bbox_t), NULL);
   bbox_make_empty_set(b);
   return b;
 }

--- a/core/point2.c
+++ b/core/point2.c
@@ -5,19 +5,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/point2.h"
 
 point2_t* point2_new(real_t x, real_t y)
 {
-  point2_t* p = GC_MALLOC(sizeof(point2_t));
+  point2_t* p = polymec_gc_malloc(sizeof(point2_t), NULL);
   p->x = x, p->y = y;
   return p;
 }
 
 vector2_t* vector2_new(real_t vx, real_t vy)
 {
-  vector2_t* v = GC_MALLOC(sizeof(vector2_t));
+  vector2_t* v = polymec_gc_malloc(sizeof(vector2_t), NULL);
   v->x = vx, v->y = vy;
   return v;
 }

--- a/core/polymec.c
+++ b/core/polymec.c
@@ -127,11 +127,11 @@ static void shutdown()
   polymec_timer_report();
 
   // Kill command line arguments.
-  free(polymec_invoc_str);
-  free(polymec_invoc_dir);
+  string_free(polymec_invoc_str);
+  string_free(polymec_invoc_dir);
   for (int i = 0; i < polymec_argc; ++i)
-    free(polymec_argv[i]);
-  free(polymec_argv);
+    string_free(polymec_argv[i]);
+  polymec_free(polymec_argv);
 
   // Finalize any remaining garbage-collected objects.
   if (GC_should_invoke_finalizers())
@@ -361,9 +361,9 @@ void polymec_init(int argc, char** argv)
     // Jot down the invocation time.
     polymec_invoc_time = time(NULL);
 
-    // Jot down command line args (use regular malloc).
+    // Jot down command line args.
     polymec_argc = argc;
-    polymec_argv = malloc(sizeof(char*) * argc);
+    polymec_argv = polymec_malloc(sizeof(char*) * argc);
     for (int i = 0; i < argc; ++i)
       polymec_argv[i] = string_dup(argv[i]);
 
@@ -375,7 +375,7 @@ void polymec_init(int argc, char** argv)
     int invoc_len = 2;
     for (int i = 0; i < polymec_argc; ++i)
       invoc_len += 1 + strlen(polymec_argv[i]);
-    polymec_invoc_str = malloc(sizeof(char) * invoc_len);
+    polymec_invoc_str = polymec_malloc(sizeof(char) * invoc_len);
     polymec_invoc_str[0] = '\0';
     for (int i = 0; i < polymec_argc; ++i)
     {

--- a/core/rng.c
+++ b/core/rng.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/rng.h"
 
 struct rng_t 
@@ -17,7 +16,7 @@ struct rng_t
   bool has_global_state, is_thread_safe;
 };
 
-static void rng_free(void* ctx, void* dummy)
+static void rng_free(void* ctx)
 {
   rng_t* rng = ctx;
   string_free(rng->name);
@@ -31,7 +30,7 @@ rng_t* rng_new(const char* name, void* context,
 {
   ASSERT(min < max);
   ASSERT(vtable.get != NULL);
-  rng_t* rng = GC_MALLOC(sizeof(rng_t));
+  rng_t* rng = polymec_gc_malloc(sizeof(rng_t), rng_free);
   rng->name = string_dup(name);
   rng->context = context;
   rng->min = min;
@@ -39,7 +38,6 @@ rng_t* rng_new(const char* name, void* context,
   rng->vtable = vtable;
   rng->has_global_state = has_global_state;
   rng->is_thread_safe = is_thread_safe;
-  GC_register_finalizer(rng, rng_free, rng, NULL, NULL);
   return rng;
 }
 

--- a/core/serializer.c
+++ b/core/serializer.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/serializer.h"
 #include "core/unordered_map.h"
 
@@ -30,7 +29,7 @@ static void destroy_serializer_registry()
   serializer_registry_free(registry);
 }
 
-static void serializer_free(void* ctx, void* dummy)
+static void serializer_free(void* ctx)
 {
   serializer_t* s = ctx;
   string_free(s->name);
@@ -59,13 +58,12 @@ serializer_t* serializer_new(const char* name,
   serializer_t** s_ptr = serializer_registry_get(registry, (char*)name);
   if (s_ptr == NULL)
   {
-    s = GC_MALLOC(sizeof(serializer_t));
+    s = polymec_gc_malloc(sizeof(serializer_t), serializer_free);
     s->name = string_dup(name);
     s->size = size_func;
     s->read = read_func;
     s->write = write_func;
     s->dtor = destructor_func;
-    GC_register_finalizer(s, serializer_free, s, NULL, NULL);
     serializer_registry_insert_with_k_dtor(registry, string_dup(name), s, string_free);
   }
   else

--- a/core/silo_file.c
+++ b/core/silo_file.c
@@ -7,7 +7,6 @@
 
 #include <sys/stat.h>
 #include <dirent.h>
-#include <gc/gc.h>
 #include "core/polymec.h"
 #if POLYMEC_HAVE_MPI
 #include "mpi.h"
@@ -90,7 +89,7 @@ struct silo_field_metadata_t
   int vector_component;
 };
 
-static void silo_field_metadata_free(void* ctx, void* dummy)
+static void silo_field_metadata_free(void* ctx)
 {
   silo_field_metadata_t* metadata = ctx;
   if (metadata->label)
@@ -101,13 +100,13 @@ static void silo_field_metadata_free(void* ctx, void* dummy)
 
 silo_field_metadata_t* silo_field_metadata_new()
 {
-  silo_field_metadata_t* metadata = GC_MALLOC(sizeof(silo_field_metadata_t));
+  silo_field_metadata_t* metadata = polymec_gc_malloc(sizeof(silo_field_metadata_t),
+                                                      silo_field_metadata_free);
   metadata->label = NULL;
   metadata->units = NULL;
   metadata->conserved = false;
   metadata->extensive = false;
   metadata->vector_component = -1;
-  GC_register_finalizer(metadata, silo_field_metadata_free, metadata, NULL, NULL);
   return metadata;
 }
 

--- a/core/silo_file.c
+++ b/core/silo_file.c
@@ -617,7 +617,10 @@ static void write_provenance_to_file(silo_file_t* file)
   fclose(stream);
 
   silo_file_write_string(file, "provenance", provenance_str);
-  string_free(provenance_str);
+
+  // Note we have to use free here instead of string_free or polymec_free, 
+  // since open_memstream uses vanilla malloc and realloc.
+  free(provenance_str);
 }
 
 #if POLYMEC_HAVE_MPI

--- a/core/sp_func.c
+++ b/core/sp_func.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/sp_func.h"
 
 struct sp_func_t 
@@ -20,7 +19,7 @@ struct sp_func_t
   sp_func_t* derivs[4];
 };
 
-static void sp_func_free(void* ctx, void* dummy)
+static void sp_func_free(void* ctx)
 {
   sp_func_t* func = ctx;
   if ((func->vtable.dtor != NULL) && (func->context != NULL))
@@ -37,14 +36,13 @@ sp_func_t* sp_func_new(const char* name, void* context, sp_func_vtable vtable,
   ASSERT(vtable.eval != NULL);
   ASSERT((vtable.eval_deriv == NULL) || (vtable.has_deriv != NULL));
   ASSERT(num_comp > 0);
-  sp_func_t* f = GC_MALLOC(sizeof(sp_func_t));
+  sp_func_t* f = polymec_gc_malloc(sizeof(sp_func_t), sp_func_free);
   f->name = string_dup(name);
   f->context = context;
   f->vtable = vtable;
   f->homogeneous = (homogeneity == SP_FUNC_HOMOGENEOUS);
   f->num_comp = num_comp;
   memset(f->derivs, 0, sizeof(sp_func_t*)*4);
-  GC_register_finalizer(f, sp_func_free, f, NULL, NULL);
   return f;
 }
 
@@ -54,14 +52,13 @@ sp_func_t* sp_func_from_func(const char* name, sp_eval_func func,
 {
   ASSERT(func != NULL);
   ASSERT(num_comp > 0);
-  sp_func_t* f = GC_MALLOC(sizeof(sp_func_t));
+  sp_func_t* f = polymec_gc_malloc(sizeof(sp_func_t), sp_func_free);
   f->name = string_dup(name);
   f->context = NULL;
   f->vtable.eval = func;
   f->homogeneous = (homogeneity == SP_FUNC_HOMOGENEOUS);
   f->num_comp = num_comp;
   memset(f->derivs, 0, sizeof(sp_func_t*)*4);
-  GC_register_finalizer(f, &sp_func_free, f, NULL, NULL);
   return f;
 }
 

--- a/core/tensor2.c
+++ b/core/tensor2.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/tensor2.h"
 #include "core/linear_algebra.h"
 
@@ -13,7 +12,7 @@ tensor2_t* tensor2_new(real_t xx, real_t xy, real_t xz,
                        real_t yx, real_t yy, real_t yz,
                        real_t zx, real_t zy, real_t zz)
 {
-  tensor2_t* t = GC_MALLOC(sizeof(tensor2_t));
+  tensor2_t* t = polymec_gc_malloc(sizeof(tensor2_t), NULL);
   tensor2_set(t, xx, xy, xz, yx, yy, yz, zx, zy, zz);
   return t;
 }
@@ -29,7 +28,7 @@ sym_tensor2_t* sym_tensor2_new(real_t xx, real_t xy, real_t xz,
                                           real_t yy, real_t yz,
                                                      real_t zz)
 {
-  sym_tensor2_t* t = GC_MALLOC(sizeof(sym_tensor2_t));
+  sym_tensor2_t* t = polymec_gc_malloc(sizeof(sym_tensor2_t), NULL);
   sym_tensor2_set(t, xx, xy, xz, yy, yz, zz);
   return t;
 }

--- a/core/tests/test_string_utils.c
+++ b/core/tests/test_string_utils.c
@@ -17,7 +17,7 @@ static void test_string_dup(void** state)
   const char* s1 = "dupe me, baby!";
   char* s2 = string_dup(s1);
   assert_true(!strcmp(s2, s1));
-  free(s2);
+  string_free(s2);
 }
 
 static void test_string_ndup(void** state)
@@ -25,7 +25,7 @@ static void test_string_ndup(void** state)
   const char* s1 = "dupe me, baby!";
   char* s2 = string_ndup(s1, 7);
   assert_true(!strcmp(s2, "dupe me"));
-  free(s2);
+  string_free(s2);
 }
 
 static void test_string_casecmp(void** state)
@@ -139,7 +139,7 @@ static void test_string_substitute(void** state)
   const char* string = "The quick brown fox jumped over lazy dogs.";
   char* new_string = string_substitute(string, substitutions);
   assert_true(!strcmp(new_string, "The avuncular purple werewolf launched over hungry hyenas."));
-  free(new_string);
+  string_free(new_string);
 }
 
 int main(int argc, char* argv[]) 

--- a/geometry/coord_mapping.c
+++ b/geometry/coord_mapping.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/linear_algebra.h"
 #include "geometry/coord_mapping.h"
 
@@ -16,7 +15,7 @@ struct coord_mapping_t
   coord_mapping_vtable vtable;
 };
 
-static void coord_mapping_free(void* ctx, void* dummy)
+static void coord_mapping_free(void* ctx)
 {
   coord_mapping_t* mapping = (coord_mapping_t*)ctx;
   if (mapping->vtable.dtor)
@@ -29,11 +28,10 @@ coord_mapping_t* coord_mapping_new(const char* name, void* context, coord_mappin
   ASSERT(context != NULL);
   ASSERT(vtable.map_point != NULL);
   ASSERT(vtable.jacobian != NULL);
-  coord_mapping_t* m = GC_MALLOC(sizeof(coord_mapping_t));
+  coord_mapping_t* m = polymec_gc_malloc(sizeof(coord_mapping_t), coord_mapping_free);
   m->name = string_dup(name);
   m->context = context;
   m->vtable = vtable;
-  GC_register_finalizer(m, coord_mapping_free, m, NULL, NULL);
   return m;
 }
 

--- a/geometry/cubic_lattice.c
+++ b/geometry/cubic_lattice.c
@@ -8,14 +8,13 @@
 #include "core/polymec.h"
 #include "core/mesh.h"
 #include "geometry/cubic_lattice.h"
-#include <gc/gc.h>
 
 cubic_lattice_t* cubic_lattice_new(index_t nx, index_t ny, index_t nz)
 {
   ASSERT(nx > 0);
   ASSERT(ny > 0);
   ASSERT(nz > 0);
-  cubic_lattice_t* l = GC_MALLOC(sizeof(cubic_lattice_t));
+  cubic_lattice_t* l = polymec_gc_malloc(sizeof(cubic_lattice_t), NULL);
   l->nx = nx;
   l->ny = ny;
   l->nz = nz;

--- a/geometry/polygon.c
+++ b/geometry/polygon.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "geometry/polygon.h"
 #include "geometry/polygon2.h"
 #include "geometry/plane_sp_func.h"
@@ -22,7 +21,7 @@ struct polygon_t
   sp_func_t* plane;
 };
 
-static void polygon_free(void* ctx, void* dummy)
+static void polygon_free(void* ctx)
 {
   polygon_t* poly = ctx;
   polymec_free(poly->vertices);
@@ -93,7 +92,7 @@ polygon_t* polygon_new_with_ordering(point_t* points, int* ordering, int num_poi
   ASSERT(ordering != NULL);
   ASSERT(num_points >= 3);
   ASSERT(all_points_are_coplanar(points, num_points));
-  polygon_t* poly = GC_MALLOC(sizeof(polygon_t));
+  polygon_t* poly = polymec_gc_malloc(sizeof(polygon_t), polygon_free);
   poly->vertices = polymec_malloc(sizeof(point_t)*num_points);
   memcpy(poly->vertices, points, sizeof(point_t)*num_points);
   poly->num_vertices = num_points;
@@ -101,7 +100,6 @@ polygon_t* polygon_new_with_ordering(point_t* points, int* ordering, int num_poi
   memcpy(poly->ordering, ordering, sizeof(int)*num_points);
   polygon_compute_area(poly);
   polygon_compute_plane(poly);
-  GC_register_finalizer(poly, polygon_free, poly, NULL, NULL);
   return poly;
 }
 

--- a/geometry/polygon2.c
+++ b/geometry/polygon2.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "geometry/polygon2.h"
 #include "core/slist.h"
 
@@ -17,7 +16,7 @@ struct polygon2_t
   real_t area;
 };
 
-static void polygon2_free(void* ctx, void* dummy)
+static void polygon2_free(void* ctx)
 {
   polygon2_t* poly = ctx;
   polymec_free(poly->vertices);
@@ -50,14 +49,13 @@ polygon2_t* polygon2_new_with_ordering(point2_t* points, int* ordering, int num_
 {
   ASSERT(points != NULL);
   ASSERT(num_points >= 3);
-  polygon2_t* poly = GC_MALLOC(sizeof(polygon2_t));
+  polygon2_t* poly = polymec_gc_malloc(sizeof(polygon2_t), polygon2_free);
   poly->vertices = polymec_malloc(sizeof(point2_t)*num_points);
   memcpy(poly->vertices, points, sizeof(point2_t)*num_points);
   poly->num_vertices = num_points;
   poly->ordering = polymec_malloc(sizeof(int)*num_points);
   memcpy(poly->ordering, ordering, sizeof(int)*num_points);
   polygon2_compute_area(poly);
-  GC_register_finalizer(poly, polygon2_free, poly, NULL, NULL);
   return poly;
 }
 

--- a/geometry/tetrahedron.c
+++ b/geometry/tetrahedron.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/polymec.h"
 #include "geometry/plane_sp_func.h"
 #include "geometry/tetrahedron.h"
@@ -22,7 +21,7 @@ struct tetrahedron_t
 
 tetrahedron_t* tetrahedron_new()
 {
-  tetrahedron_t* t = GC_MALLOC(sizeof(tetrahedron_t));
+  tetrahedron_t* t = polymec_gc_malloc(sizeof(tetrahedron_t), NULL);
   real_t L = 1.0;
   real_t sqrt3 = sqrt(3.0);
   point_set(&t->vertices[0], 0.0, 0.0, 0.0);

--- a/integrators/div_free_poly_basis.c
+++ b/integrators/div_free_poly_basis.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "integrators/div_free_poly_basis.h"
 #include "integrators/sphere_integrator.h" // For spherical integrals.
 
@@ -30,7 +29,7 @@ struct div_free_poly_basis_t
 };
 
 // Destructor function -- called by garbage collector.
-static void div_free_poly_basis_free(void* ctx, void* dummy)
+static void div_free_poly_basis_free(void* ctx)
 {
   div_free_poly_basis_t* basis = ctx;
   for (int i = 0; i < basis->dim; ++i)
@@ -165,13 +164,13 @@ div_free_poly_basis_t* spherical_div_free_poly_basis_new(int degree, point_t* x0
   ASSERT(radius > 0.0);
   ASSERT(degree >= 0);
   ASSERT(degree <= 2); // FIXME
-  div_free_poly_basis_t* basis = GC_MALLOC(sizeof(div_free_poly_basis_t));
+  div_free_poly_basis_t* basis = polymec_gc_malloc(sizeof(div_free_poly_basis_t), 
+                                                   div_free_poly_basis_free);
   basis->polytope = SPHERE;
   basis->x0 = *x0;
   basis->radius = radius;
   basis->dim = basis_dim[degree];
   basis->vectors = polymec_malloc(sizeof(polynomial_vector_t) * basis->dim);
-  GC_register_finalizer(basis, div_free_poly_basis_free, basis, NULL, NULL);
 
   // Construct the naive monomial basis.
   for (int i = 0; i < basis->dim; ++i)

--- a/integrators/surface_integral.c
+++ b/integrators/surface_integral.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "gc/gc.h"
 #include "integrators/surface_integral.h"
 
 struct surface_integral_t 
@@ -21,7 +20,7 @@ struct surface_integral_t
   vector_t* normals;
 };
 
-static void surface_integral_free(void* ctx, void* dummy)
+static void surface_integral_free(void* ctx)
 {
   surface_integral_t* integ = ctx;
   if ((integ->context != NULL) && (integ->vtable.dtor != NULL))
@@ -42,7 +41,8 @@ surface_integral_t* surface_integral_new(const char* name,
   ASSERT(vtable.num_quad_points != NULL);
   ASSERT(vtable.get_quadrature != NULL);
 
-  surface_integral_t* integ = GC_MALLOC(sizeof(surface_integral_t));
+  surface_integral_t* integ = polymec_gc_malloc(sizeof(surface_integral_t),
+                                                surface_integral_free);
   integ->name = string_dup(name);
   integ->context = context;
   integ->vtable = vtable;
@@ -50,7 +50,6 @@ surface_integral_t* surface_integral_new(const char* name,
   integ->points = NULL;
   integ->weights = NULL;
   integ->normals = NULL;
-  GC_register_finalizer(integ, surface_integral_free, integ, NULL, NULL);
   return integ;
 }
 

--- a/integrators/tests/test_newton_solver.c
+++ b/integrators/tests/test_newton_solver.c
@@ -86,7 +86,7 @@ static void test_foodweb_solve(void** state, newton_solver_t* newton)
   assert_true(L2 < 1e-2);
 
   newton_solver_free(newton);
-  free(cc);
+  polymec_free(cc);
 }
 
 static void test_block_jacobi_precond_foodweb_solve(void** state)

--- a/integrators/volume_integral.c
+++ b/integrators/volume_integral.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "gc/gc.h"
 #include "integrators/volume_integral.h"
 
 struct volume_integral_t 
@@ -20,7 +19,7 @@ struct volume_integral_t
   real_t* weights;
 };
 
-static void volume_integral_free(void* ctx, void* dummy)
+static void volume_integral_free(void* ctx)
 {
   volume_integral_t* integ = ctx;
   if ((integ->context != NULL) && (integ->vtable.dtor != NULL))
@@ -39,14 +38,14 @@ volume_integral_t* volume_integral_new(const char* name,
   ASSERT(vtable.num_quad_points != NULL);
   ASSERT(vtable.get_quadrature != NULL);
 
-  volume_integral_t* integ = GC_MALLOC(sizeof(volume_integral_t));
+  volume_integral_t* integ = polymec_gc_malloc(sizeof(volume_integral_t),
+                                               volume_integral_free);
   integ->name = string_dup(name);
   integ->context = context;
   integ->vtable = vtable;
   integ->num_points = 0;
   integ->points = NULL;
   integ->weights = NULL;
-  GC_register_finalizer(integ, volume_integral_free, integ, NULL, NULL);
   return integ;
 }
 

--- a/model/aux_state.c
+++ b/model/aux_state.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "gc/gc.h"
 #include "model/aux_state.h"
 
 struct aux_state_t 
@@ -16,7 +15,7 @@ struct aux_state_t
   real_array_t* values;
 };
 
-static void aux_state_free(void* ctx, void* dummy)
+static void aux_state_free(void* ctx)
 {
   aux_state_t* state = ctx;
   int_array_free(state->types);
@@ -27,13 +26,12 @@ static void aux_state_free(void* ctx, void* dummy)
 
 aux_state_t* aux_state_new()
 {
-  aux_state_t* state = GC_MALLOC(sizeof(aux_state_t));
+  aux_state_t* state = polymec_gc_malloc(sizeof(aux_state_t), aux_state_free);
   state->types = int_array_new();
   state->indices = int_array_new();
   state->offsets = int_array_new();
   int_array_append(state->offsets, 0);
   state->values = real_array_new();
-  GC_register_finalizer(state, aux_state_free, state, NULL, NULL);
   return state;
 }
 

--- a/model/periodic_bc.c
+++ b/model/periodic_bc.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "core/point.h"
 #include "core/unordered_set.h"
 #include "model/periodic_bc.h"
@@ -116,7 +115,7 @@ struct periodic_bc_t
   void* generate_map_context;
 };
 
-static void periodic_bc_free(void* ctx, void* dummy)
+static void periodic_bc_free(void* ctx)
 {
   periodic_bc_t* bc = (periodic_bc_t*)ctx;
   free(bc->tag1);
@@ -135,11 +134,10 @@ periodic_bc_t* periodic_bc_new_with_map_func(const char* tag1, const char* tag2,
   ASSERT(tag2 != NULL);
   ASSERT(strcmp(tag1, tag2) != 0);
 
-  periodic_bc_t* bc = GC_MALLOC(sizeof(periodic_bc_t));
+  periodic_bc_t* bc = polymec_gc_malloc(sizeof(periodic_bc_t), periodic_bc_free);
   bc->type_code = _periodic_bc_type_code;
   bc->tag1 = string_dup(tag1);
   bc->tag2 = string_dup(tag2);
-  GC_register_finalizer(bc, &periodic_bc_free, bc, NULL, NULL);
 
   // Set up the map generation stuff.
   bc->generate_map = mapping_func;

--- a/model/point_basis.c
+++ b/model/point_basis.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "gc/gc.h"
 #include "model/point_basis.h"
 
 struct point_basis_t 
@@ -17,8 +16,8 @@ struct point_basis_t
 };
 
 point_basis_t* point_basis_new(const char* name, 
-                                     void* context, 
-                                     point_basis_vtable vtable)
+                               void* context, 
+                               point_basis_vtable vtable)
 {
   ASSERT(vtable.neighborhood_size != NULL);
   ASSERT(vtable.get_neighborhood_points != NULL);

--- a/model/point_kernel.c
+++ b/model/point_kernel.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "gc/gc.h"
 #include "model/point_kernel.h"
 
 struct point_kernel_t
@@ -16,7 +15,7 @@ struct point_kernel_t
   void (*dtor)(void* context);
 };
 
-static void point_kernel_free(void* ctx, void* dummy)
+static void point_kernel_free(void* ctx)
 {
   point_kernel_t* kernel = ctx;
   string_free(kernel->name);
@@ -29,12 +28,11 @@ point_kernel_t* point_kernel_new(const char* name,
                                  void (*compute)(void* context, point_t* points, real_t* kernel_sizes, int num_points, point_t* x, real_t* values, vector_t* gradients),
                                  void (*dtor)(void* context))
 {
-  point_kernel_t* kernel = GC_MALLOC(sizeof(point_kernel_t));
+  point_kernel_t* kernel = polymec_gc_malloc(sizeof(point_kernel_t), point_kernel_free);
   kernel->name = string_dup(name);
   kernel->context = context;
   kernel->compute = compute;
   kernel->dtor = dtor;
-  GC_register_finalizer(kernel, point_kernel_free, kernel, NULL, NULL);
   return kernel;
 }
 

--- a/model/point_spacing_estimator.c
+++ b/model/point_spacing_estimator.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <gc/gc.h>
 #include "model/point_spacing_estimator.h"
 
 struct point_spacing_estimator_t 
@@ -15,7 +14,7 @@ struct point_spacing_estimator_t
   point_spacing_estimator_vtable vtable;
 };
 
-static void point_spacing_estimator_free(void* ctx, void* dummy)
+static void point_spacing_estimator_free(void* ctx)
 {
   point_spacing_estimator_t* estimator = ctx;
   string_free(estimator->name);
@@ -28,11 +27,11 @@ point_spacing_estimator_t* point_spacing_estimator_new(const char* name,
                                                        point_spacing_estimator_vtable vtable)
 {
   ASSERT(vtable.dx != NULL);
-  point_spacing_estimator_t* estimator = GC_MALLOC(sizeof(point_spacing_estimator_t));
+  point_spacing_estimator_t* estimator = polymec_gc_malloc(sizeof(point_spacing_estimator_t), 
+                                                           point_spacing_estimator_free);
   estimator->name = string_dup(name);
   estimator->context = context;
   estimator->vtable = vtable;
-  GC_register_finalizer(estimator, point_spacing_estimator_free, estimator, NULL, NULL);
   return estimator;
 }
 

--- a/model/polynomial_fit.c
+++ b/model/polynomial_fit.c
@@ -90,7 +90,7 @@ static real_t* append_equation(polynomial_fit_t* fit, int component, point_t* x)
   if (fit->equations[component]->size < new_num_eq)
   {
     eq = polymec_malloc(sizeof(real_t) * (fit->num_components*dim + 1));
-    ptr_array_append_with_dtor(fit->equations[component], eq, DTOR(free));
+    ptr_array_append_with_dtor(fit->equations[component], eq, DTOR(polymec_free));
     ptr_array_append(fit->points[component], x);
   }
   else


### PR DESCRIPTION
* Added polymec_gc_malloc function for garbage collected memory. 
* Re-worked the standard allocator to use the Boehm GC to track uncollected memory, which is the way it's supposed to be used.
* Removed explicit use of the Boehm GC from the code base.

Fixes #203 