### PR TITLE
Named builds and logic for parallel diagonal scaling with HYPRE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,15 +27,15 @@ endif()
 
 # We require compilers that are pretty C11-compliant at this point.
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION STRLESS "4.9")
-  message(FATAL_ERROR "GCC v${CMAKE_C_COMPILER_VERSION} detected. v4.9 is required.")
+  message(FATAL_ERROR "GCC v${CMAKE_C_COMPILER_VERSION} detected. v4.9+ is required.")
 elseif (CMAKE_C_COMPILER_ID STREQUAL "Intel" AND CMAKE_C_COMPILER_VERSION STRLESS "16.0")
-  message(FATAL_ERROR "Intel v${CMAKE_C_COMPILER_VERSION} detected. v16.0 is required.")
+  message(FATAL_ERROR "Intel v${CMAKE_C_COMPILER_VERSION} detected. v16.0+ is required.")
 endif()
 
 # Version numbers.
 set (POLYMEC_MAJOR_VERSION 1)
-set (POLYMEC_MINOR_VERSION 3)
-set (POLYMEC_PATCH_VERSION 2)
+set (POLYMEC_MINOR_VERSION 4)
+set (POLYMEC_PATCH_VERSION 0)
 set (POLYMEC_VERSION "${POLYMEC_MAJOR_VERSION}.${POLYMEC_MINOR_VERSION}.${POLYMEC_PATCH_VERSION}")
 
 if (POLYMEC_PRECISION STREQUAL "single")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 # We declare the project here.
 project (polymec)
 
+message(STATUS "Generating project files in build directory: ${PROJECT_BINARY_DIR}")
 message(STATUS "C compiler is ${CMAKE_C_COMPILER} (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION})")
 message(STATUS "C++ compiler is ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION})")
 if (LINUX)

--- a/INSTALL
+++ b/INSTALL
@@ -60,6 +60,12 @@ Available options are:
                     development environment (IDE) instead of UNIX 
                     makefiles (default: UNIX makefiles).
 
+    build=build_name <-- Used to explicitly name a build directory (within 
+                         the build/ subdirectory), instead of having the 
+                         build system automatically generate one based on the 
+                         platform, compiler, optimization level, etc.
+                         (default: auto-generated build name).
+
     Compilers can also be selected with CC, CXX, FC. When MPI is enabled, 
     these compilers default to mpicc, mpicxx, and mpif90, respectively. 
     Otherwise their respective defaults are cc, c++, and gfortran.

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ shared     = not-set
 machine    = not-set
 travis     = not-set
 ide        = not-set
+build      = not-set
 CC         = not-set
 CXX        = not-set
 FC         = not-set
@@ -98,6 +99,11 @@ else
     BUILDDIR := ${BUILDDIR}-Debug
     CONFIG_FLAGS += -DCMAKE_BUILD_TYPE=Debug
   endif
+endif
+
+# Override the build name if we're given one.
+ifneq ($(build), not-set)
+  BUILDDIR := build/$(build)
 endif
 
 # Installation prefix.

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -901,7 +901,9 @@ static void hypre_matrix_diag_scale(void* context, void* L, void* R)
     }
 
     // Use the HYPRE extension library to do the diagonal scaling.
-    A->factory->ext_methods.HYPRE_IJMatrixDiagScale(A->A, L->v, R->v);
+    hypre_vector_t* LL = L;
+    hypre_vector_t* RR = R;
+    A->factory->ext_methods.HYPRE_IJMatrixDiagScale(A->A, LL->v, RR->v);
   }
   else
   {

--- a/core/lis_krylov_solver.c
+++ b/core/lis_krylov_solver.c
@@ -5,6 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "core/timer.h"
 #include "core/options.h"
 #include "core/krylov_solver.h"
 #include "core/linear_algebra.h"
@@ -102,6 +103,7 @@ static bool lis_solver_solve(void* context,
                              real_t* res_norm,
                              int* num_iters)
 {
+  START_FUNCTION_TIMER();
   lis_solver_t* solver = context;
   LIS_VECTOR B = b;
   LIS_VECTOR X = x;
@@ -141,6 +143,7 @@ static bool lis_solver_solve(void* context,
     lis_solver_get_iter(solver->solver, &niters);
     *num_iters = (int)niters;
   }
+  STOP_FUNCTION_TIMER();
   return solved;
 }
 
@@ -158,6 +161,8 @@ static krylov_solver_t* lis_factory_pcg_solver(void* context,
   lis_solver_create(&solver->solver);
   lis_solver_set_option("-i cg", solver->solver);
   lis_solver_set_option("-p jacobi", solver->solver);
+  lis_solver_set_option("-storage 1", solver->solver);
+  lis_solver_set_option("-initx_zeros 1", solver->solver);
 //  lis_solver_set_option("-scale jacobi", solver->solver);
   if (log_level() == LOG_DEBUG)
     lis_solver_set_option("-print 2", solver->solver);
@@ -184,6 +189,8 @@ static krylov_solver_t* lis_factory_gmres_solver(void* context,
   snprintf(gmres, 128, "-i gmres %d", krylov_dimension);
   lis_solver_set_option(gmres, solver->solver);
   lis_solver_set_option("-p ilu", solver->solver);
+  lis_solver_set_option("-storage 1", solver->solver);
+  lis_solver_set_option("-initx_zeros 1", solver->solver);
 //  lis_solver_set_option("-scale jacobi", solver->solver);
   if (log_level() == LOG_DEBUG)
     lis_solver_set_option("-print 2", solver->solver);
@@ -205,6 +212,8 @@ static krylov_solver_t* lis_factory_bicgstab_solver(void* context,
   lis_solver_t* solver = polymec_malloc(sizeof(lis_solver_t));
   lis_solver_create(&solver->solver);
   lis_solver_set_option("-i bicgstab", solver->solver);
+  lis_solver_set_option("-storage 1", solver->solver);
+  lis_solver_set_option("-initx_zeros 1", solver->solver);
   lis_solver_set_option("-p jacobi", solver->solver);
 //  lis_solver_set_option("-scale jacobi", solver->solver);
   if (log_level() == LOG_DEBUG)

--- a/integrators/tests/diurnal_integrator.c
+++ b/integrators/tests/diurnal_integrator.c
@@ -463,7 +463,7 @@ ode_integrator_t* ink_bdf_diurnal_integrator_new(krylov_factory_t* factory)
   ode_integrator_t* integ = ink_bdf_ode_integrator_new(5, MPI_COMM_SELF, factory,
                                                        J_sparsity, data, diurnal_rhs, 
                                                        diurnal_J, diurnal_dtor);
-  ink_bdf_ode_integrator_use_gmres(integ, 30);
+  ink_bdf_ode_integrator_use_bicgstab(integ);
   return integ;
 }
 

--- a/integrators/tests/diurnal_integrator.c
+++ b/integrators/tests/diurnal_integrator.c
@@ -525,7 +525,7 @@ ode_integrator_t* ink_ark_diurnal_integrator_new(krylov_factory_t* factory)
   char* solver = options_value(opts, "solver");
   if ((solver == NULL) || (string_casecmp(solver, "gmres") == 0))
     ink_ark_ode_integrator_use_gmres(integ, 30);
-  if (string_casecmp(solver, "bicgstab") == 0)
+  else if (string_casecmp(solver, "bicgstab") == 0)
     ink_ark_ode_integrator_use_bicgstab(integ);
   else
     ink_ark_ode_integrator_use_gmres(integ, 30);

--- a/integrators/tests/diurnal_integrator.c
+++ b/integrators/tests/diurnal_integrator.c
@@ -521,7 +521,14 @@ ode_integrator_t* ink_ark_diurnal_integrator_new(krylov_factory_t* factory)
                                                        J_sparsity, data, NULL, diurnal_rhs, 
                                                        NULL, false, false, 
                                                        diurnal_J, diurnal_dtor);
-  ink_ark_ode_integrator_use_gmres(integ, 30);
+  options_t* opts = options_argv();
+  char* solver = options_value(opts, "solver");
+  if ((solver == NULL) || (string_casecmp(solver, "gmres") == 0))
+    ink_ark_ode_integrator_use_gmres(integ, 30);
+  if (string_casecmp(solver, "bicgstab") == 0)
+    ink_ark_ode_integrator_use_bicgstab(integ);
+  else
+    ink_ark_ode_integrator_use_gmres(integ, 30);
   return integ;
 }
 


### PR DESCRIPTION
* Builds now can be named and referred to, replacing lists of config options.
* We added support for HYPRE_ext, an upcoming dynamically-loadable library that provides some extensions to HYPRE (and is licensed appropriately outside of Polymec).
* We made some inroads into understanding the LIS solvers in the context of poor performance with INK solvers, though a lot remains to study.

Fixes #199