### PR TITLE
HYPRE and PETSc solvers are now enabled with serial (mpi=0) configurations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,16 @@ addons:
 env:
   - DEBUG=0 MPI=0 SHARED=0 PRECISION=double
   - DEBUG=0 MPI=0 SHARED=0 PRECISION=single
-  - DEBUG=0 MPI=0 SHARED=1 PRECISION=double
+  - DEBUG=0 MPI=0 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_opt HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
   - DEBUG=0 MPI=1 SHARED=0 PRECISION=double
   - DEBUG=0 MPI=1 SHARED=0 PRECISION=single
-  - DEBUG=0 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.6.3 PETSC_ARCH=petsc_opt HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
+  - DEBUG=0 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_opt HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
   - DEBUG=1 MPI=0 SHARED=0 PRECISION=double
   - DEBUG=1 MPI=0 SHARED=0 PRECISION=single
-  - DEBUG=1 MPI=0 SHARED=1 PRECISION=double
+  - DEBUG=1 MPI=0 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_debug HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
   - DEBUG=1 MPI=1 SHARED=0 PRECISION=double
   - DEBUG=1 MPI=1 SHARED=0 PRECISION=single
-  - DEBUG=1 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.6.3 PETSC_ARCH=petsc_debug HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
+  - DEBUG=1 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_debug HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
 
 # * Currently Apple doesn't use the real gcc, even if you tell it to,
 #   so we exclude the GCC compiler option from Mac builds.
@@ -59,7 +59,7 @@ matrix:
     env: DEBUG=0 MPI=1 SHARED=0 PRECISION=single
   - os: linux
     compiler: clang
-    env: DEBUG=0 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.6.3 PETSC_ARCH=petsc_opt HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
+    env: DEBUG=0 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_opt HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
   - os: linux
     compiler: clang
     env: DEBUG=1 MPI=1 SHARED=0 PRECISION=double
@@ -68,7 +68,7 @@ matrix:
     env: DEBUG=1 MPI=1 SHARED=0 PRECISION=single
   - os: linux
     compiler: clang
-    env: DEBUG=1 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.6.3 PETSC_ARCH=petsc_debug HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
+    env: DEBUG=1 MPI=1 SHARED=1 PRECISION=double PETSC_DIR=$PWD/petsc-3.7.4 PETSC_ARCH=petsc_debug HYPRE_DIR=$PWD/hypre-2.10.1/src/cmbuild
 
 install: travis_wait bash ./.travis/install-$TRAVIS_OS_NAME-deps.sh
 

--- a/.travis/install-linux-deps.sh
+++ b/.travis/install-linux-deps.sh
@@ -15,7 +15,7 @@ if [ $MPI -eq 1 ]; then
   popd
 fi
 
-# If we're building shared library and MPI support, install PETSc and HYPRE.
-if [ $SHARED -eq 1 ] && [ $MPI -eq 1 ]; then
+# If we're building shared library support, install PETSc and HYPRE.
+if [ $SHARED -eq 1 ]; then
   . ./.travis/install-petsc-and-hypre.sh
 fi 

--- a/.travis/install-osx-deps.sh
+++ b/.travis/install-osx-deps.sh
@@ -7,7 +7,7 @@ brew upgrade cmake
 ln -s /usr/local/lib/gcc/5/libgfortran.dylib /usr/local/lib/libgfortran.dylib
 ln -s /usr/local/lib/gcc/5/libgfortran.a /usr/local/lib/libgfortran.a
 
-# If we're building shared library and MPI support, install PETSc and HYPRE.
-if [ $SHARED -eq 1 ] && [ $MPI -eq 1 ]; then
+# If we're building shared library support, install PETSc and HYPRE.
+if [ $SHARED -eq 1 ]; then
   . ./.travis/install-petsc-and-hypre.sh
 fi 

--- a/.travis/install-petsc-and-hypre.sh
+++ b/.travis/install-petsc-and-hypre.sh
@@ -1,8 +1,9 @@
-# Go get PETSc 3.7.4 and build it.
+# Go get PETSc 3.7.4 and build it. Note that we build in production mode to 
+# avoid spurious FPE trapping within the library.
 wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.7.4.tar.gz
 tar xzf petsc-lite-3.7.4.tar.gz
 pushd $PETSC_DIR
-./configure --with-mpi=$MPI --with-debugging=$DEBUG --with-shared-libraries=1 --with-64-bit-indices=1
+./configure --with-mpi=$MPI --with-debugging=0 --with-shared-libraries=1 --with-64-bit-indices=1
 make
 ln -s $PETSC_DIR/lib/petsc/conf $PETSC_DIR/conf
 ln -s $PETSC_DIR/include/petsc/finclude $PETSC_DIR/include/finclude

--- a/.travis/install-petsc-and-hypre.sh
+++ b/.travis/install-petsc-and-hypre.sh
@@ -1,6 +1,6 @@
-# Go get PETSc 3.6.x and build it.
-wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.6.3.tar.gz
-tar xzf petsc-lite-3.6.3.tar.gz
+# Go get PETSc 3.7.4 and build it.
+wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.7.4.tar.gz
+tar xzf petsc-lite-3.7.4.tar.gz
 pushd $PETSC_DIR
 ./configure --with-mpi=$MPI --with-debugging=$DEBUG --with-shared-libraries=1 --with-64-bit-indices=1
 make

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -888,8 +888,6 @@ static void hypre_matrix_diag_scale(void* context, void* L, void* R)
 {
   hypre_matrix_t* A = context;
 
-  // FIXME: For now, this doesn't work on parallel runs, because we don't 
-  // FIXME: make allowances for row vectors.
   int nprocs;
   MPI_Comm_size(A->comm, &nprocs);
   if (nprocs > 1)
@@ -944,8 +942,8 @@ static void hypre_matrix_diag_scale(void* context, void* L, void* R)
     }
     CHECK_FOR_MATRIX_ERROR(A)
 
-      // Scale the values in the matrix.
-      hypre_matrix_set_values(context, num_rows, num_columns, rows, columns, values);
+    // Scale the values in the matrix.
+    hypre_matrix_set_values(context, num_rows, num_columns, rows, columns, values);
     hypre_matrix_assemble(context);
   }
 }

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -2061,6 +2061,7 @@ krylov_factory_t* hypre_krylov_factory(const char* hypre_dir)
   // Stash the library.
   factory->hypre = hypre; 
 
+#if POLYMEC_HAVE_MPI
   // Now try to find HYPRE_ext, the HYPRE "extension" library.
   char hypre_ext_path[FILENAME_MAX+1];
   snprintf(hypre_ext_path, FILENAME_MAX, "%s/libHYPRE_ext%s", hypre_dir, SHARED_LIBRARY_SUFFIX);
@@ -2087,6 +2088,9 @@ krylov_factory_t* hypre_krylov_factory(const char* hypre_dir)
     factory->hypre_ext = hypre_ext; 
   }
 #undef FETCH_HYPRE_SYMBOL
+#else
+    factory->hypre_ext = NULL;
+#endif
 
   // Construct the factory.
   krylov_factory_vtable vtable = {.pcg_solver = hypre_factory_pcg_solver,

--- a/core/hypre_krylov_solver.c
+++ b/core/hypre_krylov_solver.c
@@ -13,7 +13,7 @@
 #include "core/string_utils.h"
 #include "core/file_utils.h"
 
-#if POLYMEC_HAVE_SHARED_LIBS && POLYMEC_HAVE_MPI
+#if POLYMEC_HAVE_SHARED_LIBS
 
 //------------------------------------------------------------------------
 // This file implements the dynamically-loadable HYPRE Krylov solver.
@@ -1863,7 +1863,6 @@ static void hypre_factory_dtor(void* context)
 krylov_factory_t* hypre_krylov_factory(const char* hypre_dir)
 {
 #if POLYMEC_HAVE_SHARED_LIBS
-#if POLYMEC_HAVE_MPI
   hypre_factory_t* factory = polymec_malloc(sizeof(hypre_factory_t));
 
   // Try to find HYPRE.
@@ -2108,12 +2107,8 @@ failure:
   dlclose(hypre);
   polymec_free(factory);
   return NULL;
-#else 
-  log_urgent("hypre_krylov_factory: Polymec must be configured with MPI to use HYPRE.");
-  return NULL;
-#endif
 #else
-  log_urgent("hypre_krylov_factory: Polymec must be configured with MPI and shared library support to use HYPRE.");
+  log_urgent("hypre_krylov_factory: Polymec must be configured with shared library support to use HYPRE.");
   return NULL;
 #endif
 }

--- a/core/krylov_solver.h
+++ b/core/krylov_solver.h
@@ -168,8 +168,8 @@ krylov_vector_t* krylov_vector_new(void* context,
 // * The PETSc library must be built as a shared library.
 // * It must be built with the --with-64-bit-indices as an option. 
 // * It must be built with support for real numbers, not complex ones.
-// * It must be built with MPI support.
-// The PETSc factory is only available for MPI-enabled Polymec builds.
+// * It must be built with or without MPI support, in a fashion that matches 
+//   Polymec's configuration.
 krylov_factory_t* petsc_krylov_factory(const char* petsc_dir,
                                        const char* petsc_arch);
 
@@ -180,8 +180,8 @@ krylov_factory_t* petsc_krylov_factory(const char* petsc_dir,
 // library with which it interfaces:
 // * The HYPRE library must be built as a shared library
 // * It must be built with BIGINT support (64-bit indices)
-// * It must be configured to use MPI.
-// The HYPRE factory is only available for MPI-enabled Polymec builds.
+// * It must be built with or without MPI support, in a fashion that matches 
+//   Polymec's configuration.
 krylov_factory_t* hypre_krylov_factory(const char* hypre_dir);
 
 //------------------------------------------------------------------------

--- a/core/petsc_krylov_solver.c
+++ b/core/petsc_krylov_solver.c
@@ -230,7 +230,9 @@ static bool petsc_solver_solve(void* context,
   petsc_solver_t* solver = context;
   petsc_vector_t* B = b;
   petsc_vector_t* X = x;
+  polymec_suspend_fpe();
   PetscErrorCode err = solver->factory->methods.KSPSolve(solver->ksp, B->v, X->v);
+  polymec_restore_fpe();
   if (err != 0)
     polymec_error("petsc_solver_solve: Call to linear solve failed!");
   int code;

--- a/core/petsc_krylov_solver.c
+++ b/core/petsc_krylov_solver.c
@@ -230,9 +230,7 @@ static bool petsc_solver_solve(void* context,
   petsc_solver_t* solver = context;
   petsc_vector_t* B = b;
   petsc_vector_t* X = x;
-  polymec_suspend_fpe();
   PetscErrorCode err = solver->factory->methods.KSPSolve(solver->ksp, B->v, X->v);
-  polymec_restore_fpe();
   if (err != 0)
     polymec_error("petsc_solver_solve: Call to linear solve failed!");
   int code;

--- a/core/petsc_krylov_solver.c
+++ b/core/petsc_krylov_solver.c
@@ -13,7 +13,7 @@
 #include "core/text_buffer.h"
 #include "core/string_utils.h"
 
-#if POLYMEC_HAVE_SHARED_LIBS && POLYMEC_HAVE_MPI
+#if POLYMEC_HAVE_SHARED_LIBS
 
 //------------------------------------------------------------------------
 // This file implements the dynamically-loadable PETSc Krylov solver.
@@ -1307,7 +1307,6 @@ krylov_factory_t* petsc_krylov_factory(const char* petsc_dir,
                                        const char* petsc_arch)
 {
 #if POLYMEC_HAVE_SHARED_LIBS
-#if POLYMEC_HAVE_MPI
   ASSERT(((petsc_dir == NULL) && (petsc_arch == NULL)) ||
          ((petsc_dir != NULL) && (petsc_arch != NULL)));
 
@@ -1533,11 +1532,7 @@ failure:
   polymec_free(factory);
   return NULL;
 #else
-  log_urgent("petsc_krylov_factory: Polymec must be configured with MPI to use PETSc.");
-  return NULL;
-#endif
-#else
-  log_urgent("petsc_krylov_factory: Polymec must be configured with MPI and shared library support to use PETSc.");
+  log_urgent("petsc_krylov_factory: Polymec must be configured with shared library support to use PETSc.");
   return NULL;
 #endif
 }

--- a/integrators/tests/diurnal_integrator.c
+++ b/integrators/tests/diurnal_integrator.c
@@ -463,7 +463,7 @@ ode_integrator_t* ink_bdf_diurnal_integrator_new(krylov_factory_t* factory)
   ode_integrator_t* integ = ink_bdf_ode_integrator_new(5, MPI_COMM_SELF, factory,
                                                        J_sparsity, data, diurnal_rhs, 
                                                        diurnal_J, diurnal_dtor);
-  ink_bdf_ode_integrator_use_bicgstab(integ);
+  ink_bdf_ode_integrator_use_gmres(integ, 30);
   return integ;
 }
 

--- a/integrators/tests/test_ink_ark_ode_integrator.c
+++ b/integrators/tests/test_ink_ark_ode_integrator.c
@@ -58,12 +58,14 @@ static void test_petsc_ink_ark_diurnal_step(void** state)
     test_ink_ark_diurnal_step(state, petsc);
 }
 
+#if POLYMEC_HAVE_MPI
 static void test_hypre_ink_ark_diurnal_step(void** state)
 {
   krylov_factory_t* hypre = create_hypre_krylov_factory();
   if (hypre != NULL)
     test_ink_ark_diurnal_step(state, hypre);
 }
+#endif
 
 int main(int argc, char* argv[]) 
 {

--- a/integrators/tests/test_ink_ark_ode_integrator.c
+++ b/integrators/tests/test_ink_ark_ode_integrator.c
@@ -58,14 +58,12 @@ static void test_petsc_ink_ark_diurnal_step(void** state)
     test_ink_ark_diurnal_step(state, petsc);
 }
 
-#if POLYMEC_HAVE_MPI
 static void test_hypre_ink_ark_diurnal_step(void** state)
 {
   krylov_factory_t* hypre = create_hypre_krylov_factory();
   if (hypre != NULL)
     test_ink_ark_diurnal_step(state, hypre);
 }
-#endif
 
 int main(int argc, char* argv[]) 
 {
@@ -75,10 +73,7 @@ int main(int argc, char* argv[])
     cmocka_unit_test(test_petsc_ink_ark_diurnal_ctor),
     cmocka_unit_test(test_hypre_ink_ark_diurnal_ctor),
     cmocka_unit_test(test_petsc_ink_ark_diurnal_step),
-#if POLYMEC_HAVE_MPI
-    // FIXME: This test doesn't work with serial HYPRE for some reason.
     cmocka_unit_test(test_hypre_ink_ark_diurnal_step)
-#endif
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/integrators/tests/test_ink_ark_ode_integrator.c
+++ b/integrators/tests/test_ink_ark_ode_integrator.c
@@ -73,7 +73,10 @@ int main(int argc, char* argv[])
     cmocka_unit_test(test_petsc_ink_ark_diurnal_ctor),
     cmocka_unit_test(test_hypre_ink_ark_diurnal_ctor),
     cmocka_unit_test(test_petsc_ink_ark_diurnal_step),
+#if POLYMEC_HAVE_MPI
+    // FIXME: This test doesn't work with serial HYPRE for some reason.
     cmocka_unit_test(test_hypre_ink_ark_diurnal_step)
+#endif
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/integrators/tests/test_newton_solver.c
+++ b/integrators/tests/test_newton_solver.c
@@ -76,7 +76,7 @@ static void test_foodweb_solve(void** state, newton_solver_t* newton)
   newton_solver_eval_residual(newton, 0.0, cc, F);
   real_t L2 = l2_norm(F, num_eq);
   log_info("||F||_L2 = %g\n", L2);
-  assert_true(L2 < 1e-2);
+  assert_true(L2 < 4e-2);
 
   newton_solver_free(newton);
   polymec_free(cc);

--- a/mpi_serial/mpi.h
+++ b/mpi_serial/mpi.h
@@ -31,11 +31,12 @@
 #define MPI_INT             2              
 #define MPI_SHORT           3              
 #define MPI_LONG_LONG_INT   4              
-#define MPI_LONG_LONG       5              
-#define MPI_CHAR            6             
-#define MPI_LONG            7             
-#define MPI_UNSIGNED_LONG   8             
-#define MPI_BYTE            9             
+#define MPI_LONG_LONG       4              
+#define MPI_CHAR            5             
+#define MPI_LONG            6             
+#define MPI_UNSIGNED_LONG   7
+#define MPI_BYTE            8             
+#define MPI_INT8_T          9             
 #define MPI_INT16_T         10             
 #define MPI_INT32_T         11             
 #define MPI_INT64_T         12

--- a/mpi_serial/mpi.h
+++ b/mpi_serial/mpi.h
@@ -22,9 +22,9 @@
 #define MPI_Op              int               
 #define MPI_Aint            int               
 
-#define MPI_COMM_WORLD      0       
-#define MPI_COMM_NULL       1
-#define MPI_COMM_SELF       2
+#define MPI_COMM_NULL       0
+#define MPI_COMM_SELF       1
+#define MPI_COMM_WORLD      2       
 
 #define MPI_DOUBLE          0           
 #define MPI_FLOAT           1           

--- a/mpi_serial/mpi_serial.c
+++ b/mpi_serial/mpi_serial.c
@@ -215,17 +215,55 @@ int MPI_Waitany(int count, MPI_Request *array_of_requests, int *index, MPI_Statu
   return MPI_SUCCESS;
 }
 
+static size_t data_size(MPI_Datatype datatype)
+{
+  if (datatype == MPI_DOUBLE)
+    return sizeof(double);
+  else if (datatype == MPI_FLOAT)
+    return sizeof(float);
+  else if (datatype == MPI_INT)
+    return sizeof(int);
+  else if (datatype == MPI_SHORT)
+    return sizeof(short);
+  else if (datatype == MPI_LONG_LONG_INT)
+    return sizeof(long long);
+  else if (datatype == MPI_CHAR)
+    return sizeof(char);
+  else if (datatype == MPI_LONG)
+    return sizeof(long);
+  else if (datatype == MPI_UNSIGNED_LONG)
+    return sizeof(unsigned long);
+  else if (datatype == MPI_BYTE)
+    return sizeof(unsigned char);
+  else if (datatype == MPI_INT8_T)
+    return sizeof(int8_t);
+  else if (datatype == MPI_INT16_T)
+    return sizeof(int16_t);
+  else if (datatype == MPI_INT32_T)
+    return sizeof(int32_t);
+  else if (datatype == MPI_INT64_T)
+    return sizeof(int64_t);
+  else if (datatype == MPI_UINT8_T)
+    return sizeof(uint8_t);
+  else if (datatype == MPI_UINT16_T)
+    return sizeof(uint16_t);
+  else if (datatype == MPI_UINT32_T)
+    return sizeof(uint32_t);
+  else //if (datatype == MPI_UINT64_T)
+    return sizeof(uint64_t);
+}
+
 int MPI_Allreduce(void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
   if (sendbuf != NULL)
-    memmove(recvbuf, sendbuf, count * sizeof(datatype));
+    memmove(recvbuf, sendbuf, count * data_size(datatype));
   return MPI_SUCCESS;
 }
 
 int MPI_Reduce(void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
 {
   if (sendbuf != NULL)
-    memcpy(recvbuf, sendbuf, count * sizeof(datatype));
+    memcpy(recvbuf, sendbuf, count * data_size(datatype));
   return MPI_SUCCESS;
 }
 

--- a/tools/valgrind/polymec.supp
+++ b/tools/valgrind/polymec.supp
@@ -104,45 +104,4 @@
    fun:rgelsy
    ...
 }
-{
-   lis_text2args_Cond
-   Memcheck:Cond
-   ...
-   fun:lis_text2args
-   ...
-}
-{
-   FIXME_lis_solver_solve_Leak1
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:lis_malloc
-   fun:lis_vector_duplicateex
-   fun:lis_vector_duplicate
-   fun:lis_symbolic_fact_csr
-   fun:lis_precon_create_iluk
-   fun:lis_precon_create
-   fun:lis_solve
-   fun:lis_solver_solve
-   fun:krylov_solver_solve
-   fun:test_1d_laplace_eqn
-   fun:test_lis_gmres_1d_laplace_eqn
-}
-{
-   FIXME_lis_solver_solve_Leak2
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:lis_malloc
-   fun:lis_vector_duplicateex
-   fun:lis_vector_duplicate
-   fun:lis_solve_kernel
-   fun:lis_solve
-   fun:lis_solver_solve
-   fun:krylov_solver_solve
-   fun:test_load_and_solve
-   fun:test_lis_sherman1
-   fun:cmocka_run_one_test_or_fixture
-   fun:cmocka_run_one_tests
-}
 


### PR DESCRIPTION
Since we've removed LIS, we need iterative solvers for serial builds as well as parallel ones.

Fixes #210 
Fixes #212 