### PR TITLE
Lua driver now broadcasts input from rank 0 to others, includes usage info.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode7.3
+osx_image: xcode9.1
 
 compiler:
   - clang

--- a/.travis/install-osx-deps.sh
+++ b/.travis/install-osx-deps.sh
@@ -1,6 +1,6 @@
 # Install required software
 brew update
-brew install gcc openmpi lcov
+brew install --overwrite gcc openmpi lcov
 brew upgrade cmake
 
 # Make sure the weird gfortran library links are in place.

--- a/core/lua_driver.c
+++ b/core/lua_driver.c
@@ -314,6 +314,33 @@ static int pmain(lua_State* L)
 
 extern lua_State* polymec_lua_State(void);
 
+static void usage(const char* exe_name)
+{
+  if (_mpi_rank == 0)
+  {
+    printf("%s: usage:\n", exe_name);
+    printf("%s [flags] <input> [option1=val1 [option2=val2 [...]]]\n\n", exe_name);
+    printf("Flags are:\n");
+    printf(" -i            Start an interactive session (valid for 1 process only).\n");
+    printf(" --help, -h    Display help.\n\n");
+    printf("Options are:\n");
+    printf(" pause=N       Pauses for N seconds before executing, showing PID(s).\n");
+    printf(" logging=LEVEL Sets the level of detail at which messages are logged.\n");
+    printf("               Levels in ascending verbosity are:\n");
+    printf("               off,urgent,info,detail,debug\n");
+    printf(" num_threads=N Sets number of OpenMP threads to use.\n");
+    printf(" timers=VAL    Enables or disables timers.\n");
+    printf("               Case-insensitive values are:\n"); 
+    printf("               1,true,yes,on    <-- enable\n");
+    printf("               (everything else <-- disable\n");
+    printf(" dl_paths=PATH Sets path(s) to search for dynamically loaded libraries.\n");
+    printf("               PATH is a colon-delimited list of directories.\n\n");
+    printf("You can specify other options as well. All options are made available\n");
+    printf("in the options table, accessible in your input.\n");
+  }
+  exit(0);
+}
+
 int lua_driver(int argc,
                char** argv,
                int (*register_types_and_modules)(lua_State* L))
@@ -323,6 +350,14 @@ int lua_driver(int argc,
 
   MPI_Comm_rank(MPI_COMM_WORLD, &_mpi_rank);
   MPI_Comm_size(MPI_COMM_WORLD, &_mpi_nprocs);
+
+  // Look for "-h" or "--help" in the command line args and print usage 
+  // info if we find it.
+  for (int i = 1; i < argc; ++i)
+  {
+    if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0))
+      usage(argv[0]);
+  }
 
   // Set the maximum history length.
   linenoiseHistorySetMaxLen(500);

--- a/core/lua_driver.c
+++ b/core/lua_driver.c
@@ -375,7 +375,7 @@ static int pmain(lua_State* L)
 
 extern lua_State* polymec_lua_State(void);
 
-static void usage(int argc, char** argv)
+static noreturn void usage(int argc, char** argv)
 {
   // Fire up MPI real quick and fetch our rank.
   int prev_initialized, rank;

--- a/core/polymec.c
+++ b/core/polymec.c
@@ -203,6 +203,7 @@ static void set_up_logging()
   options_t* opts = options_argv();
   char* logging = options_value(opts, "logging");
   char* logging_mode = options_value(opts, "logging_mode");
+  char* log_file = options_value(opts, "log_file");
   opts = NULL;
   if (logging != NULL)
   {
@@ -241,6 +242,19 @@ static void set_up_logging()
       set_log_mpi_rank(log_level(), p);
     }
 #endif
+  }
+  if (log_file != NULL)
+  {
+    FILE* log_f = NULL;
+    char filename[FILENAME_MAX+1];
+    if (log_mode() == LOG_TO_SINGLE_RANK)
+      snprintf(filename, FILENAME_MAX, "%s.log", log_file);
+    else
+      snprintf(filename, FILENAME_MAX, "%s.%d.log", log_file, world_rank);
+    log_f = fopen(filename, "w");
+    if (log_f == NULL)
+      polymec_error("Could not open log file %s for writing.");
+    set_log_stream(log_level(), log_f);
   }
 }
 

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -56,13 +56,14 @@ add_mpi_polymec_core_test(test_repartition_point_cloud test_repartition_point_cl
 include(add_driver_test)
 add_driver_with_libs(core_driver "polymec_core;${POLYMEC_BASE_LIBRARIES}" test_core_driver.c)
 add_driver_test(test_core_driver core_driver ${CMAKE_CURRENT_SOURCE_DIR}/test_core_driver.input 1 2 4)
+add_driver_test(test_core_driver_usage core_driver --help 1 2)
 
 # Basic smoke tests of polymec/lua subsystems.
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ohai "print(\"Ohai!\")")
 add_driver_test(test_driver_bad_file core_driver bad_file)
 list(APPEND failing_tests test_driver_bad_file)
-add_driver_test(test_driver_debug_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=debug logging_mode=all)
-add_driver_test(test_driver_detail_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=detail logging_mode=single)
+add_driver_test(test_driver_debug_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=debug logging_mode=all log_file=ohai)
+add_driver_test(test_driver_detail_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=detail logging_mode=single log_file=ohai)
 add_driver_test(test_driver_info_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=info logging_mode=0)
 add_driver_test(test_driver_urgent_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=urgent)
 add_driver_test(test_driver_no_logging core_driver ${CMAKE_CURRENT_BINARY_DIR}/ohai logging=off)

--- a/model/model.c
+++ b/model/model.c
@@ -319,7 +319,7 @@ real_t model_max_dt(model_t* model, char* reason)
   if (model->max_dt < dt)
   {
     dt = model->max_dt;
-    strcpy(reason, "Max dt set in options.");
+    strcpy(reason, "Specified maximum timestep.");
   }
 
   // If we have a plot time coming up, perhaps the next one will 


### PR DESCRIPTION
* Instead of every MPI rank reading and parsing the input file, rank 0 reads and parses it, then broadcasts the executable chunk to other ranks. Then all ranks execute their chunk.
* Passing -h and --help flags to the Lua driver now causes usage info to be printed, followed by an immediate exit without initializing polymec's subsystems.
* Added a parallel-safe log_file=PREFIX option.

Fixes #241, #244 