### PR TITLE
Refactored silo_file polymesh field reading/writing/query methods

### DIFF
--- a/io/silo_file.h
+++ b/io/silo_file.h
@@ -98,193 +98,59 @@ polymesh_t* silo_file_read_polymesh(silo_file_t* file,
 // with the given name, false otherwise.
 bool silo_file_contains_polymesh(silo_file_t* file, const char* mesh_name);
 
-// Writes a named scalar cell-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. If a silo_field_metadata
-// object is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_scalar_polycell_field(silo_file_t* file,
+// Writes a named scalar field with the given centering on a polymesh, 
+// understood to exist on the polymesh with the given name within the file, 
+// to the given Silo file. If a silo_field_metadata object is passed as the 
+// last argument, the metadata for the field will also be written to the 
+// file--otherwise it can be NULL.
+void silo_file_write_scalar_polymesh_field(silo_file_t* file,
                                            const char* field_name,
                                            const char* mesh_name,
                                            real_t* field_data,
+                                           polymesh_centering_t centering,
                                            silo_field_metadata_t* field_metadata);
 
-// Reads a named scalar cell-centered field from the Silo file, returning a newly-
-// allocated array of field data. If a silo_field_metadata object is passed as 
-// the last argument, the metadata for the field will be read into it--
-// otherwise it can be NULL.
-real_t* silo_file_read_scalar_polycell_field(silo_file_t* file,
-                                             const char* field_name,
-                                             const char* mesh_name,
-                                             silo_field_metadata_t* field_metadata);
-
-// Writes a named multicomponent cell-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. The field data is 
-// interpreted to be in component-minor order. If an array of metadata
-// objects is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_polycell_field(silo_file_t* file,
+// Writes a named multicomponent field of the given centering on a polymesh, 
+// understood to exist on the polymesh with the given name, to the given Silo 
+// file. The field data is interpreted to be in component-minor order. If an 
+// array of metadata objects is passed as the last argument, the metadata for 
+// the field will also be written to the file--otherwise it can be NULL.
+void silo_file_write_polymesh_field(silo_file_t* file,
                                     const char** field_component_names,
                                     const char* mesh_name,
                                     real_t* field_data,
                                     int num_components,
+                                    polymesh_centering_t centering,
                                     silo_field_metadata_t** field_metadata);
 
-// Reads a named multicomponent cell-centered field from the Silo file, returning a 
-// newly-allocated array of field data. If an array of metadata objects is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_polycell_field(silo_file_t* file,
-                                      const char** field_component_names,
-                                      const char* mesh_name,
-                                      int num_components,
-                                      silo_field_metadata_t** field_metadata);
-
-// Returns true if the given Silo file contains a (scalar) cell-centered field 
-// with the given name and associated with the given polymesh, false otherwise.
-bool silo_file_contains_polycell_field(silo_file_t* file, 
-                                       const char* field_name,
-                                       const char* mesh_name);
-
-// Writes a named scalar face-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. If a silo_field_metadata
-// object is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_scalar_polyface_field(silo_file_t* file,
-                                           const char* field_name,
-                                           const char* mesh_name,
-                                           real_t* field_data,
-                                           silo_field_metadata_t* field_metadata);
-
-// Reads a named scalar face-centered field from the Silo file, returning a newly-
-// allocated array of field data. If a silo_field_metadata object is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_scalar_polyface_field(silo_file_t* file,
+// Reads a named scalar field with the given polymesh centering from the Silo 
+// file, returning a newly-allocated array of field data. If a 
+// silo_field_metadata object is passed as the last argument, the metadata for 
+// the field will be read into it--otherwise it can be NULL.
+real_t* silo_file_read_scalar_polymesh_field(silo_file_t* file,
                                              const char* field_name,
                                              const char* mesh_name,
+                                             polymesh_centering_t centering,
                                              silo_field_metadata_t* field_metadata);
 
-// Writes a named multicomponent face-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. The field data is 
-// interpreted to be in component-minor order. If an array of metadata
-// objects is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_polyface_field(silo_file_t* file,
-                                    const char** field_component_names,
-                                    const char* mesh_name,
-                                    real_t* field_data,
-                                    int num_components,
-                                    silo_field_metadata_t** field_metadata);
-
-// Reads a named multicomponent face-centered field from the Silo file, returning a 
-// newly-allocated array of field data. If an array of metadata objects is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_polyface_field(silo_file_t* file,
+// Reads a named multicomponent field with the given polymesh centering from 
+// the Silo file, returning a newly-allocated array of field data. If an array 
+// of metadata objects is passed as the last argument, the metadata for the 
+// field will be read into it--otherwise it can be NULL.
+real_t* silo_file_read_polymesh_field(silo_file_t* file,
                                       const char** field_component_names,
                                       const char* mesh_name,
                                       int num_components,
+                                      polymesh_centering_t centering,
                                       silo_field_metadata_t** field_metadata);
 
-// Returns true if the given Silo file contains a (scalar) face-centered field 
-// with the given name and associated with the given polymesh, false otherwise.
-bool silo_file_contains_polyface_field(silo_file_t* file, 
+// Returns true if the given Silo file contains a (scalar) field 
+// with the given centering and name, and associated with the given polymesh, 
+// false otherwise.
+bool silo_file_contains_polymesh_field(silo_file_t* file, 
                                        const char* field_name,
-                                       const char* mesh_name);
-
-// Writes a named scalar node-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. If a silo_field_metadata
-// object is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_scalar_polynode_field(silo_file_t* file,
-                                           const char* field_name,
-                                           const char* mesh_name,
-                                           real_t* field_data,
-                                           silo_field_metadata_t* field_metadata);
-
-// Reads a named scalar node-centered field from the Silo file, returning a newly-
-// allocated array of field data. If a silo_field_metadata object is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_scalar_polynode_field(silo_file_t* file,
-                                             const char* field_name,
-                                             const char* mesh_name,
-                                             silo_field_metadata_t* field_metadata);
-
-// Writes a named multicomponent node-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. The field data is 
-// interpreted to be in component-minor order. If an array of metadata
-// objects is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_polynode_field(silo_file_t* file,
-                                    const char** field_component_names,
-                                    const char* mesh_name,
-                                    real_t* field_data,
-                                    int num_components,
-                                    silo_field_metadata_t** field_metadata);
-
-// Reads a named multicomponent node-centered field from the Silo file, returning a 
-// newly-allocated array of field data. If an array of metadata objects is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_polynode_field(silo_file_t* file,
-                                      const char** field_component_names,
-                                      const char* mesh_name,
-                                      int num_components,
-                                      silo_field_metadata_t** field_metadata);
-
-// Returns true if the given Silo file contains a (scalar) node-centered field 
-// with the given name and associated with the given polymesh, false otherwise.
-bool silo_file_contains_polynode_field(silo_file_t* file, 
-                                       const char* field_name,
-                                       const char* mesh_name);
-
-// Writes a named scalar edge-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. If a silo_field_metadata object is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-void silo_file_write_scalar_polyedge_field(silo_file_t* file,
-                                           const char* field_name,
-                                           const char* mesh_name,
-                                           real_t* field_data,
-                                           silo_field_metadata_t* field_metadata);
-
-// Reads a named scalar edge-centered field from the Silo file, returning a newly-
-// allocated array of field data. If an array of metadata objects is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_scalar_polyedge_field(silo_file_t* file,
-                                             const char* field_name,
-                                             const char* mesh_name,
-                                             silo_field_metadata_t* field_metadata);
-
-// Writes a named multicomponent edge-centered field, understood to exist on 
-// the polymesh with the given name, to the given Silo file. The field data is 
-// interpreted to be in component-minor order. If an array of metadata
-// objects is passed as the last argument, the metadata for the field will also 
-// be written to the file--otherwise it can be NULL.
-void silo_file_write_polyedge_field(silo_file_t* file,
-                                    const char** field_component_names,
-                                    const char* mesh_name,
-                                    real_t* field_data,
-                                    int num_components,
-                                    silo_field_metadata_t** field_metadata);
-
-// Reads a named multicomponent edge-centered field from the Silo file, returning a 
-// newly-allocated array of field data. If an array of metadata objects is 
-// passed as the last argument, the metadata for the field will be read into 
-// it--otherwise it can be NULL.
-real_t* silo_file_read_polyedge_field(silo_file_t* file,
-                                      const char** field_component_names,
-                                      const char* mesh_name,
-                                      int num_components,
-                                      silo_field_metadata_t** field_metadata);
-
-// Returns true if the given Silo file contains a (scalar) node-centered field 
-// with the given name and associated with the given polymesh, false otherwise.
-bool silo_file_contains_polyedge_field(silo_file_t* file, 
-                                       const char* field_name,
-                                       const char* mesh_name);
+                                       const char* mesh_name,
+                                       polymesh_centering_t centering);
 
 // Adds a point cloud to the given Silo file.
 void silo_file_write_point_cloud(silo_file_t* file,

--- a/io/tests/test_create_rectilinear_polymesh_io.c
+++ b/io/tests/test_create_rectilinear_polymesh_io.c
@@ -69,7 +69,8 @@ static void test_plot_rectilinear_mesh(void** state)
   metadata->conserved = true;
   metadata->extensive = false;
   metadata->vector_component = 2;
-  silo_file_write_scalar_polycell_field(silo, "solution", "mesh", ones, metadata);
+  silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, 
+                                        POLYMESH_CELL, metadata);
 
   // Add some fields with different centerings.
   real_t nvals[3*mesh->num_nodes]; 
@@ -80,17 +81,19 @@ static void test_plot_rectilinear_mesh(void** state)
     nvals[3*n+1] = mesh->nodes[n].y;
     nvals[3*n+2] = mesh->nodes[n].z;
   }
-  silo_file_write_polynode_field(silo, nnames, "mesh", nvals, 3, NULL);
+  silo_file_write_polymesh_field(silo, nnames, "mesh", nvals, 3, POLYMESH_NODE, NULL);
 
   real_t fvals[mesh->num_faces];
   for (int f = 0; f < mesh->num_faces; ++f)
     fvals[f] = 1.0 * f;
-  silo_file_write_scalar_polyface_field(silo, "fvals", "mesh", fvals, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "fvals", "mesh", fvals, 
+                                        POLYMESH_FACE, NULL);
 
   real_t evals[mesh->num_edges];
   for (int e = 0; e < mesh->num_edges; ++e)
     evals[e] = 1.0 * e;
-  silo_file_write_scalar_polyedge_field(silo, "evals", "mesh", evals, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "evals", "mesh", evals, 
+                                        POLYMESH_EDGE, NULL);
 
   silo_file_close(silo);
 
@@ -105,8 +108,8 @@ static void test_plot_rectilinear_mesh(void** state)
   assert_true(silo_file_contains_polymesh(silo, "mesh"));
   mesh = silo_file_read_polymesh(silo, "mesh");
   assert_true(mesh->num_cells <= 4*4*4);
-  assert_true(silo_file_contains_polycell_field(silo, "solution", "mesh"));
-  real_t* ones1 = silo_file_read_scalar_polycell_field(silo, "solution", "mesh", metadata);
+  assert_true(silo_file_contains_polymesh_field(silo, "solution", "mesh", POLYMESH_CELL));
+  real_t* ones1 = silo_file_read_scalar_polymesh_field(silo, "solution", "mesh", POLYMESH_CELL, metadata);
   for (int i = 0; i < mesh->num_cells; ++i)
   {
     assert_true(reals_equal(ones1[i], ones[i]));
@@ -119,26 +122,26 @@ static void test_plot_rectilinear_mesh(void** state)
   metadata = NULL;
 
   // Check on the other fields.
-  assert_true(silo_file_contains_polynode_field(silo, "nx", "mesh"));
-  assert_true(silo_file_contains_polynode_field(silo, "ny", "mesh"));
-  assert_true(silo_file_contains_polynode_field(silo, "nz", "mesh"));
-  real_t* nvals1 = silo_file_read_polynode_field(silo, nnames, "mesh", 3, NULL);
+  assert_true(silo_file_contains_polymesh_field(silo, "nx", "mesh", POLYMESH_NODE));
+  assert_true(silo_file_contains_polymesh_field(silo, "ny", "mesh", POLYMESH_NODE));
+  assert_true(silo_file_contains_polymesh_field(silo, "nz", "mesh", POLYMESH_NODE));
+  real_t* nvals1 = silo_file_read_polymesh_field(silo, nnames, "mesh", 3, POLYMESH_NODE, NULL);
   for (int n = 0; n < mesh->num_nodes; ++n)
   {
     assert_true(reals_equal(nvals[n], nvals1[n]));
   }
   polymec_free(nvals1);
 
-  assert_true(silo_file_contains_polyface_field(silo, "fvals", "mesh"));
-  real_t* fvals1 = silo_file_read_scalar_polyface_field(silo, "fvals", "mesh", NULL);
+  assert_true(silo_file_contains_polymesh_field(silo, "fvals", "mesh", POLYMESH_FACE));
+  real_t* fvals1 = silo_file_read_scalar_polymesh_field(silo, "fvals", "mesh", POLYMESH_FACE, NULL);
   for (int f = 0; f < mesh->num_faces; ++f)
   {
     assert_true(reals_equal(fvals[f], fvals1[f]));
   }
   polymec_free(fvals1);
 
-  assert_true(silo_file_contains_polyedge_field(silo, "evals", "mesh"));
-  real_t* evals1 = silo_file_read_scalar_polyedge_field(silo, "evals", "mesh", NULL);
+  assert_true(silo_file_contains_polymesh_field(silo, "evals", "mesh", POLYMESH_EDGE));
+  real_t* evals1 = silo_file_read_scalar_polymesh_field(silo, "evals", "mesh", POLYMESH_EDGE, NULL);
   for (int e = 0; e < mesh->num_edges; ++e)
   {
     assert_true(reals_equal(evals[e], evals1[e]));

--- a/io/tests/test_create_uniform_polymesh_io.c
+++ b/io/tests/test_create_uniform_polymesh_io.c
@@ -61,7 +61,7 @@ static void test_plot_uniform_mesh_with_num_files(void** state, int num_files)
   snprintf(prefix, FILENAME_MAX, "uniform_mesh_%dx%dx%d_%df", nx, ny, nz, num_files);
   silo_file_t* silo = silo_file_new(mesh->comm, prefix, "", num_files, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
-  silo_file_write_scalar_polycell_field(silo, "solution", "mesh", ones, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   // Query the plot file to make sure its numbers are good.

--- a/io/tests/test_crop_polymesh_io.c
+++ b/io/tests/test_crop_polymesh_io.c
@@ -65,7 +65,7 @@ static void test_cylindrical_crop(void** state)
     ones[c] = 1.0*c;
   silo_file_t* silo = silo_file_new(cropped_mesh->comm, "cyl_cropped_mesh", "", 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", cropped_mesh);
-  silo_file_write_scalar_polycell_field(silo, "solution", "mesh", ones, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   polymesh_free(cropped_mesh);
@@ -90,7 +90,7 @@ static void test_spherical_crop(void** state)
     ones[c] = 1.0*c;
   silo_file_t* silo = silo_file_new(cropped_mesh->comm, "sph_cropped_mesh", "", 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", cropped_mesh);
-  silo_file_write_scalar_polycell_field(silo, "solution", "mesh", ones, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   polymesh_free(cropped_mesh);

--- a/io/tests/test_partition_polymesh_io.c
+++ b/io/tests/test_partition_polymesh_io.c
@@ -92,7 +92,7 @@ static void test_partition_linear_mesh(void** state)
   p_metadata->conserved = true;
   silo_file_t* silo = silo_file_new(mesh->comm, "linear_mesh_partition", "linear_mesh_partition", 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
-  silo_file_write_scalar_polycell_field(silo, "rank", "mesh", p, p_metadata);
+  silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, p_metadata);
   silo_file_close(silo);
 
   // Clean up.
@@ -152,7 +152,7 @@ static void test_partition_slab_mesh(void** state)
     p[c] = 1.0*rank;
   silo_file_t* silo = silo_file_new(mesh->comm, "slab_mesh_partition", "slab_mesh_partition", 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
-  silo_file_write_scalar_polycell_field(silo, "rank", "mesh", p, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   // Clean up.
@@ -212,7 +212,7 @@ static void test_partition_box_mesh(void** state)
     p[c] = 1.0*rank;
   silo_file_t* silo = silo_file_new(mesh->comm, "box_mesh_partition", "box_mesh_partition", 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
-  silo_file_write_scalar_polycell_field(silo, "rank", "mesh", p, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   // Clean up.

--- a/io/tests/test_repartition_polymesh_io.c
+++ b/io/tests/test_repartition_polymesh_io.c
@@ -210,7 +210,7 @@ static void test_repartition_uniform_mesh_of_size(void** state, int nx, int ny, 
   snprintf(prefix, FILENAME_MAX, "%dx%dx%d_uniform_mesh_repartition", nx, ny, nz);
   silo_file_t* silo = silo_file_new(mesh->comm, prefix, prefix, 1, 0, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
-  silo_file_write_scalar_polycell_field(silo, "rank", "mesh", r, NULL);
+  silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", r, POLYMESH_CELL, NULL);
   silo_file_close(silo);
 
   // Clean up.


### PR DESCRIPTION
Instead of having separate methods for polymesh cell/face/edge/node fields, we now use methods that take field centerings as arguments. This is no more difficult to understand, and shrinks the API.

No new features in this pull request!