### PR TITLE
Added silo_file_open_as_rank function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,8 +299,8 @@ include_directories("${PROJECT_SOURCE_DIR}")
 add_subdirectory(core)
 add_subdirectory(geometry)
 add_subdirectory(solvers)
-add_subdirectory(io)
 add_subdirectory(model)
+add_subdirectory(io)
 
 # Now that we have gathered all our libraries, generate a polymec.cmake 
 # file that contains all the vital information.

--- a/core/allocators.c
+++ b/core/allocators.c
@@ -234,13 +234,13 @@ static int lua_finalize_object(lua_State* L)
   // Fetch our destructor.
   gc_finalizer_t* storage_f = (gc_finalizer_t*)storage;
   void (*finalize)(void*) = storage_f[2].finalize;
-  ASSERT(finalize != NULL);
 
   // Fetch our object.
   void* obj = &(storage_f[3]);
 
-  // Finalize the object.
-  finalize(obj);
+  // Finalize the object if needed.
+  if (finalize != NULL)
+    finalize(obj);
   
   return 0;
 }
@@ -270,12 +270,9 @@ void* polymec_gc_malloc(size_t size, void (*finalize)(void* memory))
   // for a userdata of the desired size preceded by 2 ints and a finalizer.
   void* storage = lua_newuserdata(L, 3 * sizeof(gc_finalizer_t) + size);
 
-  // If we're given a finalizer, set the metatable for this object.
-  if (finalize != NULL)
-  {
-    luaL_getmetatable(L, GC_C_OBJ);
-    lua_setmetatable(L, -2);
-  }
+  // Set the metatable for this object.
+  luaL_getmetatable(L, GC_C_OBJ);
+  lua_setmetatable(L, -2);
 
   // Get a key for this object and stash it at the front of the userdata.
   int ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/io/lua_io.c
+++ b/io/lua_io.c
@@ -47,7 +47,7 @@ static int silo_new(lua_State* L)
     time = (real_t)(lua_tonumber(L, -1));
   lua_pop(L, 1);
 
-  silo_file_t* s = silo_file_new(MPI_COMM_WORLD, prefix, dir, num_files, 0, step, time);
+  silo_file_t* s = silo_file_new(MPI_COMM_WORLD, prefix, dir, num_files, step, time);
   lua_push_silo_file(L, s);
   return 1;
 }
@@ -84,7 +84,7 @@ static int silo_open(lua_State* L)
   lua_pop(L, 1);
 
   real_t time;
-  silo_file_t* s = silo_file_open(MPI_COMM_WORLD, prefix, dir, 0, step, &time);
+  silo_file_t* s = silo_file_open(MPI_COMM_WORLD, prefix, dir, step, &time);
   lua_push_silo_file(L, s);
   return 1;
 }

--- a/io/silo_file.c
+++ b/io/silo_file.c
@@ -11,9 +11,9 @@
 
 // Poor Man's Parallel I/O stuff.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Werror"
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Werror"
 #include "pmpio.h"
 #pragma GCC diagnostic pop
 #pragma clang diagnostic pop

--- a/io/silo_file.c
+++ b/io/silo_file.c
@@ -1479,7 +1479,6 @@ silo_file_t* silo_file_open_as_rank(MPI_Comm comm,
 void silo_file_close(silo_file_t* file)
 {
   START_FUNCTION_TIMER();
-#if POLYMEC_HAVE_MPI
   if (file->nproc > 1)
   {
     // Finish working on this process.
@@ -1504,7 +1503,7 @@ void silo_file_close(silo_file_t* file)
 
     // We use the baton's communicator for this barrier, since 
     // silo_file_open_as_rank complicates the role of a silo file's
-    // communicator
+    // communicator.
     MPI_Barrier(baton_comm);
 
     if (file->subdomain_meshes != NULL)
@@ -1521,15 +1520,6 @@ void silo_file_close(silo_file_t* file)
     }
     DBClose(file->dbfile);
   }
-#else
-  // Write the file.
-  if (file->mode == DB_CLOBBER)
-  {
-    write_expressions_to_file(file, file->dbfile);
-    write_provenance_to_file(file);
-  }
-  DBClose(file->dbfile);
-#endif
   log_debug("silo_file_close: Closed file.");
 
   // Clean up.

--- a/io/silo_file.c
+++ b/io/silo_file.c
@@ -11,9 +11,9 @@
 
 // Poor Man's Parallel I/O stuff.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=unused-function"
+#pragma GCC diagnostic ignored "-Wunused-function"
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Werror=unused-function"
+#pragma clang diagnostic ignored "-Wunused-function"
 #include "pmpio.h"
 #pragma GCC diagnostic pop
 #pragma clang diagnostic pop

--- a/io/silo_file.c
+++ b/io/silo_file.c
@@ -850,6 +850,7 @@ silo_file_t* silo_file_new(MPI_Comm comm,
 
   silo_file_t* file = polymec_malloc(sizeof(silo_file_t));
   file->expressions = string_ptr_unordered_map_new();
+  file->mpi_tag = SILO_FILE_MPI_TAG;
 
   set_prefix(file, file_prefix);
 
@@ -862,7 +863,6 @@ silo_file_t* silo_file_new(MPI_Comm comm,
   else
     file->num_files = num_files;
   ASSERT(file->num_files <= file->nproc);
-  file->mpi_tag = SILO_FILE_MPI_TAG;
 
   if (file->nproc > 1)
   {
@@ -947,6 +947,12 @@ silo_file_t* silo_file_new(MPI_Comm comm,
   }
   set_root_dir(file);
 #else
+  file->nproc = 1;
+  file->rank = 0;
+  file->num_files = 1;
+  file->group_rank = 0;
+  file->rank_in_group = 0;
+
   if (strlen(directory) == 0)
     strncpy(file->directory, ".", FILENAME_MAX);
   else
@@ -1053,6 +1059,7 @@ silo_file_t* silo_file_open(MPI_Comm comm,
   file->step = -1;
   file->time = -REAL_MAX;
   file->expressions = NULL;
+  file->mpi_tag = SILO_FILE_MPI_TAG;
 
   set_prefix(file, file_prefix);
 
@@ -1130,7 +1137,6 @@ silo_file_t* silo_file_open(MPI_Comm comm,
   MPI_Comm_rank(file->comm, &file->rank); 
   file->num_files = num_files; // number of files in the data set.
   file->nproc = num_mpi_procs; // number of MPI procs used to write the thing.
-  file->mpi_tag = SILO_FILE_MPI_TAG;
 
   if (file->nproc > 1)
   {
@@ -1224,6 +1230,11 @@ silo_file_t* silo_file_open(MPI_Comm comm,
     show_provenance_on_debug_log(file);
   }
 #else
+  file->nproc = 1;
+  file->rank = 0;
+  file->num_files = 1;
+  file->group_rank = 0;
+  file->rank_in_group = 0;
   if (strlen(directory) == 0)
     strncpy(file->directory, ".", FILENAME_MAX);
   else

--- a/io/silo_file.h
+++ b/io/silo_file.h
@@ -58,30 +58,55 @@ bool silo_file_query(const char* file_prefix,
 // Creates and opens a new Silo file for writing simulation data, 
 // returning the Silo file object. If step is non-negative, the file associates 
 // itself with the given simulation step number, which is incorporated into 
-// its filename. If directory is the blank string (""), a directory named 
-// <prefix>_<nprocs>procs is generated and used.
+// its filename. 
+// * If directory is the blank string (""), a directory named 
+//   <prefix>_<nprocs>procs is generated and used for parallel runs. For 
+//   serial runs, the current working directory is used.
+// * If the step is -1, the most recent step will be loaded, unless no files 
+//   with step information can be found, in which case the single set of files 
+//   containing no step information will be loaded. 
+// * If the file cannot be created, this function returns NULL.
 silo_file_t* silo_file_new(MPI_Comm comm,
                            const char* file_prefix,
                            const char* directory,
                            int num_files,
-                           int mpi_tag,
                            int step,
                            real_t time);
 
 // Opens an existing Silo file for reading simulation data, returning the 
-// Silo file object. If the directory is the blank string(""), the directory 
-// is assumed to be the current working directory. If the step is -1, the 
-// most recent step will be loaded, unless no files with step information 
-// can be found, in which case the single set of files containing no step 
-// information will be loaded. If time is not NULL, it will store the time 
-// found in the file (or 0.0 if it does not exist in the file).
-// If the file does not exist or fails to load, this function returns NULL.
+// Silo file object. 
+// * If directory is the blank string (""), a directory named 
+//   <prefix>_<nprocs>procs is generated and used for parallel runs. For 
+//   serial runs, the current working directory is used.
+// * If the step is -1, the most recent step will be loaded, unless no files 
+//   with step information can be found, in which case the single set of files 
+//   containing no step information will be loaded. 
+// * If time is not NULL, it will store the time found in the file (or 0.0 if 
+//   it does not exist in the file).
+// * If the file does not exist or fails to load, this function returns NULL.
 silo_file_t* silo_file_open(MPI_Comm comm,
                             const char* file_prefix,
                             const char* directory,
-                            int mpi_tag,
                             int step, 
                             real_t* time);
+
+// Opens an existing Silo file for reading simulation data, masquerading as 
+// the given MPI rank. Returns the Silo file object that stores data 
+// originally written by the given rank. 
+// * If directory is the blank string (""), a directory named 
+//   <prefix>_<nprocs>procs is generated and used for parallel runs. For 
+//   serial runs, the current working directory is used.
+// * If the step is -1, the most recent step will be loaded, unless no files 
+//   with step information can be found, in which case the single set of files 
+//   containing no step information will be loaded. 
+// * If time is not NULL, it will store the time found in the file (or 0.0 if 
+//   it does not exist in the file).
+// * If the file does not exist or fails to load, this function returns NULL.
+silo_file_t* silo_file_open_as_rank(int mpi_rank,
+                                    const char* file_prefix,
+                                    const char* directory,
+                                    int step, 
+                                    real_t* time);
 
 // Closes and destroys the given Silo file, writing all its data to disk.
 void silo_file_close(silo_file_t* file);

--- a/io/silo_file.h
+++ b/io/silo_file.h
@@ -12,6 +12,7 @@
 #include "core/point_cloud.h"
 #include "core/slist.h"
 #include "geometry/polymesh.h"
+#include "model/neighbor_pairing.h"
 
 // Enables GZIP compression at the given level for Silo files. This is 
 // invoked globally and effects all file writes until it is set to a different 
@@ -281,5 +282,40 @@ exchanger_t* silo_file_read_exchanger(silo_file_t* file, const char* exchanger_n
 
 // Writes an exchanger object with the given name.
 void silo_file_write_exchanger(silo_file_t* file, const char* exchanger_name, exchanger_t* ex);
+
+// Returns true if the given silo_file contains a stencil with the given 
+// name, false otherwise.
+bool silo_file_contains_stencil(silo_file_t* file, const char* stencil_name);
+
+// Writes a stencil object with the given name.
+void silo_file_write_stencil(silo_file_t* file,
+                             const char* stencil_name,
+                             stencil_t* stencil);
+
+// This function extends the silo_file type to allow it to read in and 
+// return a newly-allocated stencil object from the entry in the 
+// file with the given name. The exchanger for the stencil is assigned
+// to the given MPI communicator.
+stencil_t* silo_file_read_stencil(silo_file_t* file,
+                                  const char* stencil_name,
+                                  MPI_Comm comm);
+
+// Returns true if the given silo file contains a neighbor_pairing object 
+// with the given name, false otherwise.
+bool silo_file_contains_neighbor_pairing(silo_file_t* file,
+                                         const char* neighbors_name);
+
+// Writes a neighbor_pairing object to an entry with the given name.
+void silo_file_write_neighbor_pairing(silo_file_t* file,
+                                      const char* neighbors_name,
+                                      neighbor_pairing_t* neighbors);
+
+// This function extends the silo_file type to allow it to read in and 
+// return a newly-allocated neighbor_pairing object from the entry in the 
+// file with the given name. The exchanger for the neighbor pairing is assigned
+// to the given MPI communicator.
+neighbor_pairing_t* silo_file_read_neighbor_pairing(silo_file_t* file,
+                                                    const char* neighbors_name,
+                                                    MPI_Comm comm);
 
 #endif

--- a/io/silo_file.h
+++ b/io/silo_file.h
@@ -91,8 +91,8 @@ silo_file_t* silo_file_open(MPI_Comm comm,
                             real_t* time);
 
 // Opens an existing Silo file for reading simulation data, masquerading as 
-// the given MPI rank. Returns the Silo file object that stores data 
-// originally written by the given rank. 
+// the given MPI rank in the given communicator. Returns the Silo file object 
+// that stores data originally written by the given rank. 
 // * If directory is the blank string (""), a directory named 
 //   <prefix>_<nprocs>procs is generated and used for parallel runs. For 
 //   serial runs, the current working directory is used.
@@ -102,7 +102,8 @@ silo_file_t* silo_file_open(MPI_Comm comm,
 // * If time is not NULL, it will store the time found in the file (or 0.0 if 
 //   it does not exist in the file).
 // * If the file does not exist or fails to load, this function returns NULL.
-silo_file_t* silo_file_open_as_rank(int mpi_rank,
+silo_file_t* silo_file_open_as_rank(MPI_Comm comm,
+                                    int mpi_rank,
                                     const char* file_prefix,
                                     const char* directory,
                                     int step, 

--- a/io/tests/CMakeLists.txt
+++ b/io/tests/CMakeLists.txt
@@ -2,11 +2,11 @@ include(add_polymec_test)
 
 # These functions create the tests for our io library.
 function(add_polymec_io_test exe)
-  add_polymec_test_with_libs(${exe} "polymec_io;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
+  add_polymec_test_with_libs(${exe} "polymec_io;polymec_model;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
 endfunction()
 
 function(add_mpi_polymec_io_test exe)
-  add_mpi_polymec_test_with_libs(${exe} "polymec_io;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
+  add_mpi_polymec_test_with_libs(${exe} "polymec_io;polymec_model;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
 endfunction()
 
 add_mpi_polymec_io_test(test_partition_polymesh_io test_partition_polymesh_io.c 1 2 3 4)
@@ -16,5 +16,6 @@ add_mpi_polymec_io_test(test_repartition_point_cloud_io test_repartition_point_c
 add_mpi_polymec_io_test(test_create_uniform_polymesh_io test_create_uniform_polymesh_io.c 1 2 4)
 add_mpi_polymec_io_test(test_create_rectilinear_polymesh_io test_create_rectilinear_polymesh_io.c 1 2 3 4)
 add_mpi_polymec_io_test(test_crop_polymesh_io test_crop_polymesh_io.c 1 2 4)
+add_mpi_polymec_io_test(test_star_stencil_io test_star_stencil_io.c 1 2 3 4)
 
 

--- a/io/tests/test_create_rectilinear_polymesh_io.c
+++ b/io/tests/test_create_rectilinear_polymesh_io.c
@@ -61,7 +61,7 @@ static void test_plot_rectilinear_mesh(void** state)
   real_t ones[4*4*4];
   for (int c = 0; c < 4*4*4; ++c)
     ones[c] = 1.0*c;
-  silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "rectilinear_4x4x4", "", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "rectilinear_4x4x4", "", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_field_metadata_t* metadata = silo_field_metadata_new();
   metadata->label = string_dup("solution");
@@ -103,7 +103,7 @@ static void test_plot_rectilinear_mesh(void** state)
   // Now read the mesh from the file.
   metadata = silo_field_metadata_new();
   real_t t;
-  silo = silo_file_open(MPI_COMM_WORLD, "rectilinear_4x4x4", "", 0, 0, &t);
+  silo = silo_file_open(MPI_COMM_WORLD, "rectilinear_4x4x4", "", 0, &t);
   assert_true(reals_equal(t, 0.0));
   assert_true(silo_file_contains_polymesh(silo, "mesh"));
   mesh = silo_file_read_polymesh(silo, "mesh");

--- a/io/tests/test_create_rectilinear_polymesh_io.c
+++ b/io/tests/test_create_rectilinear_polymesh_io.c
@@ -119,7 +119,7 @@ static void test_plot_rectilinear_mesh(void** state)
   assert_true(metadata->conserved);
   assert_false(metadata->extensive);
   assert_int_equal(2, metadata->vector_component);
-  metadata = NULL;
+  polymec_free(ones1);
 
   // Check on the other fields.
   assert_true(silo_file_contains_polymesh_field(silo, "nx", "mesh", POLYMESH_NODE));
@@ -147,10 +147,45 @@ static void test_plot_rectilinear_mesh(void** state)
     assert_true(reals_equal(evals[e], evals1[e]));
   }
   polymec_free(evals1);
+  silo_file_close(silo);
 
+  // Open the file once more, this time using silo_file_open_as_rank, to make 
+  // sure that the process can read from a specific rank correctly.
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  silo = silo_file_open_as_rank(MPI_COMM_WORLD, rank, "rectilinear_4x4x4", "", 0, &t);
+  assert_true(reals_equal(t, 0.0));
+  assert_true(silo_file_contains_polymesh(silo, "mesh"));
+  polymesh_t* mesh1 = silo_file_read_polymesh(silo, "mesh");
+  assert_int_equal(mesh->num_cells, mesh1->num_cells);
+  assert_int_equal(mesh->num_faces, mesh1->num_faces);
+  assert_int_equal(mesh->num_edges, mesh1->num_edges);
+  assert_int_equal(mesh->num_nodes, mesh1->num_nodes);
+  for (int i = 0; i < mesh1->num_cells; ++i)
+  {
+    int pos = 0, pos1 = 0, f, f1;
+    while (polymesh_cell_next_face(mesh, i, &pos, &f))
+    {
+      assert_true(polymesh_cell_next_face(mesh1, i, &pos1, &f1));
+      assert_int_equal(f, f1);
+    }
+  }
+  assert_true(silo_file_contains_polymesh_field(silo, "solution", "mesh", POLYMESH_CELL));
+  ones1 = silo_file_read_scalar_polymesh_field(silo, "solution", "mesh", POLYMESH_CELL, metadata);
+  for (int i = 0; i < mesh1->num_cells; ++i)
+  {
+    assert_true(reals_equal(ones1[i], ones[i]));
+  }
+  assert_int_equal(0, strcmp(metadata->label, "solution"));
+  assert_int_equal(0, strcmp(metadata->units, "quatloo"));
+  assert_true(metadata->conserved);
+  assert_false(metadata->extensive);
+  assert_int_equal(2, metadata->vector_component);
   silo_file_close(silo);
 
   polymec_free(ones1);
+  polymec_release(metadata);
+  polymesh_free(mesh1);
   polymesh_free(mesh);
 }
 

--- a/io/tests/test_create_uniform_polymesh_io.c
+++ b/io/tests/test_create_uniform_polymesh_io.c
@@ -59,7 +59,7 @@ static void test_plot_uniform_mesh_with_num_files(void** state, int num_files)
     ones[c] = 1.0*c;
   char prefix[FILENAME_MAX];
   snprintf(prefix, FILENAME_MAX, "uniform_mesh_%dx%dx%d_%df", nx, ny, nz, num_files);
-  silo_file_t* silo = silo_file_new(mesh->comm, prefix, "", num_files, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(mesh->comm, prefix, "", num_files, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);

--- a/io/tests/test_crop_polymesh_io.c
+++ b/io/tests/test_crop_polymesh_io.c
@@ -63,7 +63,7 @@ static void test_cylindrical_crop(void** state)
   real_t ones[Nx*Ny*Nz];
   for (int c = 0; c < Nx*Ny*Nz; ++c)
     ones[c] = 1.0*c;
-  silo_file_t* silo = silo_file_new(cropped_mesh->comm, "cyl_cropped_mesh", "", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(cropped_mesh->comm, "cyl_cropped_mesh", "", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", cropped_mesh);
   silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);
@@ -88,7 +88,7 @@ static void test_spherical_crop(void** state)
   real_t ones[Nx*Ny*Nz];
   for (int c = 0; c < Nx*Ny*Nz; ++c)
     ones[c] = 1.0*c;
-  silo_file_t* silo = silo_file_new(cropped_mesh->comm, "sph_cropped_mesh", "", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(cropped_mesh->comm, "sph_cropped_mesh", "", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", cropped_mesh);
   silo_file_write_scalar_polymesh_field(silo, "solution", "mesh", ones, POLYMESH_CELL, NULL);
   silo_file_close(silo);

--- a/io/tests/test_partition_point_cloud_io.c
+++ b/io/tests/test_partition_point_cloud_io.c
@@ -52,7 +52,7 @@ static void test_partition_linear_cloud(void** state, int N)
     p[i] = 1.0*rank;
   char filename[FILENAME_MAX];
   snprintf(filename, FILENAME_MAX, "linear_cloud_partition_%d", N);
-  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0.0);
   silo_file_write_point_cloud(silo, "cloud", cloud);
   silo_field_metadata_t* metadata = silo_field_metadata_new();
   metadata->label = string_dup("rank");
@@ -71,7 +71,7 @@ static void test_partition_linear_cloud(void** state, int N)
   // Now read the cloud from the file.
   metadata = silo_field_metadata_new();
   real_t t;
-  silo = silo_file_open(MPI_COMM_WORLD, filename, filename, 0, 0, &t);
+  silo = silo_file_open(MPI_COMM_WORLD, filename, filename, 0, &t);
   assert_true(reals_equal(t, 0.0));
   assert_true(silo_file_contains_point_cloud(silo, "cloud"));
   cloud = silo_file_read_point_cloud(silo, "cloud");
@@ -120,7 +120,7 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
     p[i] = 1.0*rank;
   char filename[FILENAME_MAX];
   snprintf(filename, FILENAME_MAX, "planar_cloud_partition_%dx%d", nx, ny);
-  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0.0);
   silo_file_write_point_cloud(silo, "cloud", cloud);
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);
@@ -160,7 +160,7 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
     p[i] = 1.0*rank;
   char filename[FILENAME_MAX];
   snprintf(filename, FILENAME_MAX, "cubic_cloud_partition_%dx%dx%d", nx, ny, nz);
-  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0.0);
   silo_file_write_point_cloud(silo, "cloud", cloud);
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);

--- a/io/tests/test_partition_polymesh_io.c
+++ b/io/tests/test_partition_polymesh_io.c
@@ -90,7 +90,7 @@ static void test_partition_linear_mesh(void** state)
   silo_field_metadata_t* p_metadata = silo_field_metadata_new();
   p_metadata->label = string_dup("P");
   p_metadata->conserved = true;
-  silo_file_t* silo = silo_file_new(mesh->comm, "linear_mesh_partition", "linear_mesh_partition", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(mesh->comm, "linear_mesh_partition", "linear_mesh_partition", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, p_metadata);
   silo_file_close(silo);
@@ -150,7 +150,7 @@ static void test_partition_slab_mesh(void** state)
   real_t p[mesh->num_cells];
   for (int c = 0; c < mesh->num_cells; ++c)
     p[c] = 1.0*rank;
-  silo_file_t* silo = silo_file_new(mesh->comm, "slab_mesh_partition", "slab_mesh_partition", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(mesh->comm, "slab_mesh_partition", "slab_mesh_partition", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, NULL);
   silo_file_close(silo);
@@ -210,7 +210,7 @@ static void test_partition_box_mesh(void** state)
   real_t p[mesh->num_cells];
   for (int c = 0; c < mesh->num_cells; ++c)
     p[c] = 1.0*rank;
-  silo_file_t* silo = silo_file_new(mesh->comm, "box_mesh_partition", "box_mesh_partition", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(mesh->comm, "box_mesh_partition", "box_mesh_partition", 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", p, POLYMESH_CELL, NULL);
   silo_file_close(silo);

--- a/io/tests/test_repartition_point_cloud_io.c
+++ b/io/tests/test_repartition_point_cloud_io.c
@@ -155,7 +155,7 @@ static void test_repartition_linear_cloud(void** state,
   snprintf(dataset_name, 1024, "%s_%s_%s_linear_cloud_repartition", 
            balance_str, random_str, weight_str);
 
-  silo_file_t* silo = silo_file_new(comm, dataset_name, dataset_name, 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(comm, dataset_name, dataset_name, 1, 0, 0.0);
   silo_file_write_point_cloud(silo, "cloud", cloud);
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);

--- a/io/tests/test_repartition_polymesh_io.c
+++ b/io/tests/test_repartition_polymesh_io.c
@@ -208,7 +208,7 @@ static void test_repartition_uniform_mesh_of_size(void** state, int nx, int ny, 
     r[c] = 1.0*rank;
   char prefix[FILENAME_MAX];
   snprintf(prefix, FILENAME_MAX, "%dx%dx%d_uniform_mesh_repartition", nx, ny, nz);
-  silo_file_t* silo = silo_file_new(mesh->comm, prefix, prefix, 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(mesh->comm, prefix, prefix, 1, 0, 0.0);
   silo_file_write_polymesh(silo, "mesh", mesh);
   silo_file_write_scalar_polymesh_field(silo, "rank", "mesh", r, POLYMESH_CELL, NULL);
   silo_file_close(silo);

--- a/io/tests/test_star_stencil_io.c
+++ b/io/tests/test_star_stencil_io.c
@@ -1,0 +1,139 @@
+// Copyright (c) 2012-2017, Jeffrey N. Johnson
+// All rights reserved.
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include "cmocka.h"
+#include "core/unordered_set.h"
+#include "core/timer.h"
+#include "geometry/cubic_lattice.h"
+#include "geometry/create_uniform_polymesh.h"
+#include "model/polymesh_stencils.h"
+#include "io/silo_file.h"
+
+static void test_NXxNYxNZ_star_stencil(void** state, 
+                                       MPI_Comm comm,
+                                       int radius,
+                                       int nx, int ny, int nz,
+                                       int num_interior_neighbors, 
+                                       int num_boundary_neighbors, 
+                                       int num_edge_neighbors,
+                                       int num_corner_neighbors)
+{
+  bbox_t bbox = {.x1 = 0.0, .x2 = 1.0, .y1 = 0.0, .y2 = 1.0, .z1 = 0.0, .z2 = 1.0};
+  polymesh_t* mesh = create_uniform_polymesh(comm, nx, ny, nz, &bbox);
+  stencil_t* stencil = cell_star_stencil_new(mesh, radius);
+
+  // Write the stencil to a Silo file.
+  char prefix[FILENAME_MAX+1];
+  if (comm == MPI_COMM_WORLD)
+    snprintf(prefix, FILENAME_MAX, "star_all");
+  else
+  {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    snprintf(prefix, FILENAME_MAX, "star_p%d", rank);
+  }
+  silo_file_t* silo = silo_file_new(comm, prefix, "star", 1, 0, 0, 0.0);
+  silo_file_write_stencil(silo, "stencil", stencil);
+  silo_file_close(silo);
+
+  // Make sure the file is written before we attempt to read it!
+  MPI_Barrier(comm);
+
+  // Read the stencil from the file and check its contents.
+  real_t t;
+  silo = silo_file_open(comm, prefix, "star", 0, 0, &t);
+  assert_true(silo_file_contains_stencil(silo, "stencil"));
+  stencil_t* stencil1 = silo_file_read_stencil(silo, "stencil", comm);
+  silo_file_close(silo);
+  int N = stencil_num_indices(stencil);
+  assert_int_equal(N, stencil_num_indices(stencil1));
+  for (int i = 0; i < N; ++i)
+  {
+    int pos = 0, pos1 = 0, j, j1;
+    while (stencil_next(stencil, i, &pos, &j))
+    {
+      assert_true(stencil_next(stencil1, i, &pos1, &j1));
+      assert_int_equal(j, j1);
+    }
+  }
+  stencil_free(stencil1);
+  stencil_free(stencil);
+  polymesh_free(mesh);
+}
+
+static void test_serial_1x1x1_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 1, 1, 1, 0, 0, 0, 0);
+  STOP_FUNCTION_TIMER();
+}
+
+static void test_serial_10x1x1_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 1, 1, 0, 0, 2, 1);
+  STOP_FUNCTION_TIMER();
+}
+
+static void test_serial_10x10x1_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 1, 4, 4, 3, 2);
+  STOP_FUNCTION_TIMER();
+}
+
+static void test_serial_10x10x10_cell_star_stencil(void** state)
+{
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_SELF, 1, 10, 10, 10, 6, 5, 4, 3);
+  START_FUNCTION_TIMER();
+  STOP_FUNCTION_TIMER();
+}
+
+#if POLYMEC_HAVE_MPI
+static void test_parallel_10x1x1_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 1, 1, 0, 0, 2, 1);
+  STOP_FUNCTION_TIMER();
+}
+
+static void test_parallel_10x10x1_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 1, 4, 4, 3, 2);
+  STOP_FUNCTION_TIMER();
+}
+
+static void test_parallel_10x10x10_cell_star_stencil(void** state)
+{
+  START_FUNCTION_TIMER();
+  test_NXxNYxNZ_star_stencil(state, MPI_COMM_WORLD, 1, 10, 10, 10, 6, 5, 4, 3);
+  STOP_FUNCTION_TIMER();
+}
+#endif
+
+int main(int argc, char* argv[]) 
+{
+  polymec_init(argc, argv);
+  const struct CMUnitTest tests[] = 
+  {
+    cmocka_unit_test(test_serial_1x1x1_cell_star_stencil),
+    cmocka_unit_test(test_serial_10x1x1_cell_star_stencil),
+    cmocka_unit_test(test_serial_10x10x1_cell_star_stencil),
+    cmocka_unit_test(test_serial_10x10x10_cell_star_stencil)
+#if POLYMEC_HAVE_MPI
+   ,cmocka_unit_test(test_parallel_10x1x1_cell_star_stencil),
+    cmocka_unit_test(test_parallel_10x10x1_cell_star_stencil),
+    cmocka_unit_test(test_parallel_10x10x10_cell_star_stencil)
+#endif
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/io/tests/test_star_stencil_io.c
+++ b/io/tests/test_star_stencil_io.c
@@ -40,7 +40,7 @@ static void test_NXxNYxNZ_star_stencil(void** state,
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     snprintf(prefix, FILENAME_MAX, "star_p%d", rank);
   }
-  silo_file_t* silo = silo_file_new(comm, prefix, "star", 1, 0, 0, 0.0);
+  silo_file_t* silo = silo_file_new(comm, prefix, "star", 1, 0, 0.0);
   silo_file_write_stencil(silo, "stencil", stencil);
   silo_file_close(silo);
 
@@ -49,7 +49,7 @@ static void test_NXxNYxNZ_star_stencil(void** state,
 
   // Read the stencil from the file and check its contents.
   real_t t;
-  silo = silo_file_open(comm, prefix, "star", 0, 0, &t);
+  silo = silo_file_open(comm, prefix, "star", 0, &t);
   assert_true(silo_file_contains_stencil(silo, "stencil"));
   stencil_t* stencil1 = silo_file_read_stencil(silo, "stencil", comm);
   silo_file_close(silo);

--- a/model/lua_model.c
+++ b/model/lua_model.c
@@ -385,6 +385,20 @@ static int m_run(lua_State* L)
   else if (!lua_isnil(L, -1))
     return luaL_error(L, "load_step must be a step.");
 
+  model_diag_mode_t diag_mode = MODEL_DIAG_NEAREST_STEP;
+  lua_getfield(L, 2, "diag_mode");
+  if (lua_isstring(L, -1))
+  {
+    const char* mode_str = lua_tostring(L, -1);
+    if (strcasecmp(mode_str, "exact_time") == 0)
+      diag_mode = MODEL_DIAG_EXACT_TIME;
+    else if (strcasecmp(mode_str, "nearest_step") != 0)
+      return luaL_error(L, "diag_mode must be a 'nearest_step' or 'exact_time'.");
+    model_set_diagnostic_mode(m, diag_mode);
+  }
+  else if (!lua_isnil(L, -1))
+    return luaL_error(L, "diag_mode must be a 'nearest_step' or 'exact_time'.");
+
   real_t min_dt = 0.0;
   lua_getfield(L, 2, "min_dt");
   if (lua_isnumber(L, -1))

--- a/model/model.h
+++ b/model/model.h
@@ -90,6 +90,21 @@ typedef enum
   MODEL_MPI_THREAD_SAFE 
 } model_parallelism_t;
 
+// This type identifies one of two possible modes of operation for 
+// diagnostics: plots and probe measurements:
+// 1. MODEL_DIAG_EXACT_TIME: This tells the model to create plots and 
+//    acquire probe measurements at the exact time at which they are requested,
+//    altering the simulation to set time step sizes so that these data can 
+//    be collected.
+// 2. MODEL_DIAG_NEAREST_STEP: This tells the model to create plots and 
+//    acquire probe measurements on the step that falls nearest its requested
+//    time. In this setting, time steps are not chosen to collect measurements.
+typedef enum
+{ 
+   MODEL_DIAG_EXACT_TIME,
+   MODEL_DIAG_NEAREST_STEP
+} model_diag_mode_t;
+
 // Creates an instance of a model with the given name and characteristics.
 // The name should uniquely identify the model, BUT SHOULD NOT BE SPECIFIC 
 // TO THE INSTANCE OF THE MODEL. Constructors that use this function should 
@@ -202,6 +217,9 @@ void model_save_every(model_t* model, int n);
 
 // Tells the model to load its state from a given step.
 void model_load_from(model_t* model, int step);
+
+// Sets the diagnostic mode for the model to collect measurements.
+void model_set_diagnostic_mode(model_t* model, model_diag_mode_t mode);
 
 // Retrieves (a copy of) the virtual table for the given model.
 model_vtable model_get_vtable(model_t* model);

--- a/model/neighbor_pairing.c
+++ b/model/neighbor_pairing.c
@@ -336,46 +336,6 @@ matrix_sparsity_t* sparsity_from_point_cloud_and_neighbors(point_cloud_t* points
   return sparsity;
 }
 
-void silo_file_write_neighbor_pairing(silo_file_t* file,
-                                      const char* neighbors_name,
-                                      neighbor_pairing_t* neighbors)
-{
-  char name_name[FILENAME_MAX];
-  snprintf(name_name, FILENAME_MAX, "%s_neighbor_pairing_name", neighbors_name);
-  silo_file_write_string(file, name_name, neighbors->name);
-  char pairs_name[FILENAME_MAX];
-  snprintf(pairs_name, FILENAME_MAX, "%s_neighbor_pairing_pairs", neighbors_name);
-  silo_file_write_int_array(file, pairs_name, neighbors->pairs, 2*neighbors->num_pairs);
-
-  if (neighbors->ex != NULL)
-  {
-    char ex_name[FILENAME_MAX];
-    snprintf(ex_name, FILENAME_MAX, "%s_neighbor_pairing_ex", neighbors_name);
-    silo_file_write_exchanger(file, ex_name, neighbors->ex);
-  }
-}
-
-neighbor_pairing_t* silo_file_read_neighbor_pairing(silo_file_t* file,
-                                                    const char* neighbors_name,
-                                                    MPI_Comm comm)
-{
-  neighbor_pairing_t* p = polymec_malloc(sizeof(neighbor_pairing_t));
-  char name_name[FILENAME_MAX];
-  snprintf(name_name, FILENAME_MAX, "%s_neighbor_pairing_name", neighbors_name);
-  p->name = silo_file_read_string(file, name_name);
-  char pairs_name[FILENAME_MAX];
-  snprintf(pairs_name, FILENAME_MAX, "%s_neighbor_pairing_pairs", neighbors_name);
-  size_t size;
-  p->pairs = silo_file_read_int_array(file, pairs_name, &size);
-  ASSERT((size % 2) == 0);
-  p->num_pairs = (int)size/2;
-
-  char ex_name[FILENAME_MAX];
-  snprintf(ex_name, FILENAME_MAX, "%s_neighbor_pairing_ex", neighbors_name);
-  p->ex = silo_file_read_exchanger(file, ex_name, comm);
-  return p;
-}
-
 neighbor_pairing_t* distance_based_neighbor_pairing_new(point_cloud_t* points,
                                                         real_t* R,
                                                         int* num_ghost_points)

--- a/model/neighbor_pairing.h
+++ b/model/neighbor_pairing.h
@@ -106,20 +106,6 @@ adj_graph_t* graph_from_point_cloud_and_neighbors(point_cloud_t* points,
 matrix_sparsity_t* sparsity_from_point_cloud_and_neighbors(point_cloud_t* points, 
                                                            neighbor_pairing_t* neighbors);
 
-// This function extends the silo_file type to allow it to write out a 
-// neighbor_pairing object to an entry with the given name.
-void silo_file_write_neighbor_pairing(silo_file_t* file,
-                                      const char* neighbors_name,
-                                      neighbor_pairing_t* neighbors);
-
-// This function extends the silo_file type to allow it to read in and 
-// return a newly-allocated neighbor_pairing object from the entry in the 
-// file with the given name. The exchanger for the neighbor pairing is assigned
-// to the given MPI communicator.
-neighbor_pairing_t* silo_file_read_neighbor_pairing(silo_file_t* file,
-                                                    const char* neighbors_name,
-                                                    MPI_Comm comm);
-
 // This is a shake-n-bake method for constructing pairs of neighboring 
 // points using a neighbor relationship that relates points (xi, xj) that are 
 // closer to each other than a specified distance Dij = max(R[i], R[j]), where 

--- a/model/stencil.c
+++ b/model/stencil.c
@@ -215,78 +215,12 @@ serializer_t* stencil_serializer()
   return serializer_new("stencil", stencil_byte_size, stencil_byte_read, stencil_byte_write, DTOR(stencil_free));
 }
 
-matrix_sparsity_t* sparsity_from_stencil(stencil_t* stencil)
+matrix_sparsity_t* matrix_sparsity_from_stencil(stencil_t* stencil)
 {
   adj_graph_t* g = stencil_as_graph(stencil);
   matrix_sparsity_t* sp = matrix_sparsity_from_graph(g, stencil->ex);
   adj_graph_free(g);
   return sp;
-}
-
-bool silo_file_contains_stencil(silo_file_t* file, const char* stencil_name)
-{
-  char name[FILENAME_MAX+1];
-  snprintf(name, FILENAME_MAX, "%s_stencil_name", stencil_name);
-  return silo_file_contains_string(file, name);
-}
-
-void silo_file_write_stencil(silo_file_t* file,
-                             const char* stencil_name,
-                             stencil_t* stencil)
-{
-  START_FUNCTION_TIMER();
-  char name_name[FILENAME_MAX+1];
-  snprintf(name_name, FILENAME_MAX, "%s_stencil_name", stencil_name);
-  silo_file_write_string(file, name_name, stencil->name);
-
-  char offsets_name[FILENAME_MAX+1];
-  snprintf(offsets_name, FILENAME_MAX, "%s_stencil_offsets", stencil_name);
-  silo_file_write_int_array(file, offsets_name, stencil->offsets, stencil->num_indices+1);
-
-  char indices_name[FILENAME_MAX+1];
-  snprintf(indices_name, FILENAME_MAX, "%s_stencil_indices", stencil_name);
-  silo_file_write_int_array(file, indices_name, stencil->indices, stencil->offsets[stencil->num_indices]);
-
-  if (stencil->ex != NULL)
-  {
-    char ex_name[FILENAME_MAX+1];
-    snprintf(ex_name, FILENAME_MAX, "%s_stencil_ex", stencil_name);
-    silo_file_write_exchanger(file, ex_name, stencil->ex);
-  }
-  STOP_FUNCTION_TIMER();
-}
-
-stencil_t* silo_file_read_stencil(silo_file_t* file,
-                                  const char* stencil_name,
-                                  MPI_Comm comm)
-{
-  START_FUNCTION_TIMER();
-  stencil_t* s = polymec_malloc(sizeof(stencil_t));
-  char name_name[FILENAME_MAX+1];
-  snprintf(name_name, FILENAME_MAX, "%s_stencil_name", stencil_name);
-  s->name = silo_file_read_string(file, name_name);
-
-  char offsets_name[FILENAME_MAX+1];
-  snprintf(offsets_name, FILENAME_MAX, "%s_stencil_offsets", stencil_name);
-  size_t size;
-  s->offsets = silo_file_read_int_array(file, offsets_name, &size);
-  s->num_indices = (int)(size) - 1;
-
-  if (s->offsets[s->num_indices] > 0)
-  {
-    char indices_name[FILENAME_MAX+1];
-    snprintf(indices_name, FILENAME_MAX, "%s_stencil_indices", stencil_name);
-    s->indices = silo_file_read_int_array(file, indices_name, &size);
-    ASSERT((int)size == s->offsets[s->num_indices]);
-  }
-  else
-    s->indices = NULL;
-
-  char ex_name[FILENAME_MAX+1];
-  snprintf(ex_name, FILENAME_MAX, "%s_stencil_ex", stencil_name);
-  s->ex = silo_file_read_exchanger(file, ex_name, comm);
-  STOP_FUNCTION_TIMER();
-  return s;
 }
 
 stencil_t* distance_based_point_stencil_new(point_cloud_t* points,

--- a/model/stencil.h
+++ b/model/stencil.h
@@ -15,7 +15,6 @@
 #include "core/point_cloud.h"
 #include "core/adj_graph.h"
 #include "solvers/matrix_sparsity.h"
-#include "io/silo_file.h"
 
 // A stencil is a set of indices associated with a stencil for some spatial 
 // discretization. Stencils can be constructed for any set of indices 
@@ -119,25 +118,7 @@ adj_graph_t* stencil_as_graph(stencil_t* stencil);
 serializer_t* stencil_serializer(void);
 
 // Returns a newly-created matrix sparsity constructed from this stencil.
-matrix_sparsity_t* sparsity_from_stencil(stencil_t* stencil);
-
-// This function extends the silo_file type to allow it to write out a 
-// stencil object to an entry with the given name.
-void silo_file_write_stencil(silo_file_t* file,
-                             const char* stencil_name,
-                             stencil_t* stencil);
-
-// This function extends the silo_file type to allow it to read in and 
-// return a newly-allocated stencil object from the entry in the 
-// file with the given name. The exchanger for the stencil is assigned
-// to the given MPI communicator.
-stencil_t* silo_file_read_stencil(silo_file_t* file,
-                                  const char* stencil_name,
-                                  MPI_Comm comm);
-
-// Returns true if the given silo_file contains a stencil with the given 
-// name, false otherwise.
-bool silo_file_contains_stencil(silo_file_t* file, const char* stencil_name);
+matrix_sparsity_t* matrix_sparsity_from_stencil(stencil_t* stencil);
 
 // This pre-fab function creates a stencil for points in a cloud that have 
 // neighbors within a radius given by R[i] for the ith point. num_ghost_points

--- a/model/tests/CMakeLists.txt
+++ b/model/tests/CMakeLists.txt
@@ -2,11 +2,11 @@ include(add_polymec_test)
 
 # These functions create the tests for our model library.
 function(add_polymec_model_test exe)
-  add_polymec_test_with_libs(${exe} "polymec_model;polymec_io;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
+  add_polymec_test_with_libs(${exe} "polymec_model;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
 endfunction()
 
 function(add_mpi_polymec_model_test exe)
-  add_mpi_polymec_test_with_libs(${exe} "polymec_model;polymec_io;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
+  add_mpi_polymec_test_with_libs(${exe} "polymec_model;polymec_solvers;polymec_geometry;polymec_core;${POLYMEC_BASE_LIBRARIES}" ${ARGN})
 endfunction()
 
 # Some of these tests need some source files from our geometry library.

--- a/model/tests/test_partition_point_cloud_with_neighbors.c
+++ b/model/tests/test_partition_point_cloud_with_neighbors.c
@@ -11,8 +11,8 @@
 #include <string.h>
 #include "cmocka.h"
 #include "geometry/create_point_lattice.h"
-#include "io/silo_file.h"
 #include "model/partition_point_cloud_with_neighbors.h"
+//#include "io/silo_file.h"
 
 // This creates a neighbor pairing using a hat function.
 extern neighbor_pairing_t* create_simple_pairing(point_cloud_t* cloud, real_t h);
@@ -53,6 +53,7 @@ static void test_partition_linear_cloud(void** state, int N)
     assert_true(reals_nearly_equal(z, 0.5, 1e-6));
   }
 
+#if 0
   // Plot it.
   real_t p[cloud->num_points];
   for (int i = 0; i < cloud->num_points; ++i)
@@ -76,6 +77,7 @@ static void test_partition_linear_cloud(void** state, int N)
   assert_true(silo_file_query(filename, filename, &num_files, &num_procs, NULL));
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
+#endif
 }
 
 static void test_partition_planar_cloud(void** state, int nx, int ny)
@@ -114,7 +116,6 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
     assert_true(reals_nearly_equal(y, 0.0, 1e-6));
     assert_true(reals_nearly_equal(z, 0.0, 1e-6));
   }
-#endif
 
   // Plot it.
   real_t p[cloud->num_points];
@@ -139,6 +140,7 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
   assert_true(silo_file_query(filename, filename, &num_files, &num_procs, NULL));
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
+#endif
 }
 
 static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
@@ -177,7 +179,6 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
     assert_true(reals_nearly_equal(y, 0.0, 1e-6));
     assert_true(reals_nearly_equal(z, 0.0, 1e-6));
   }
-#endif
 
   // Plot it.
   real_t p[cloud->num_points];
@@ -202,6 +203,7 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
   assert_true(silo_file_query(filename, filename, &num_files, &num_procs, NULL));
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
+#endif
 }
 
 static void test_partition_small_linear_cloud(void** state)

--- a/model/tests/test_partition_point_cloud_with_neighbors.c
+++ b/model/tests/test_partition_point_cloud_with_neighbors.c
@@ -65,10 +65,6 @@ static void test_partition_linear_cloud(void** state, int N)
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);
 
-  // Clean up.
-  neighbor_pairing_free(pairing);
-  point_cloud_free(cloud);
-
   // Make sure all processes have written to the file.
   MPI_Barrier(comm);
 
@@ -78,6 +74,10 @@ static void test_partition_linear_cloud(void** state, int N)
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
 #endif
+
+  // Clean up.
+  neighbor_pairing_free(pairing);
+  point_cloud_free(cloud);
 }
 
 static void test_partition_planar_cloud(void** state, int nx, int ny)
@@ -128,10 +128,6 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);
 
-  // Clean up.
-  neighbor_pairing_free(pairing);
-  point_cloud_free(cloud);
-
   // Make sure all processes have written to the file.
   MPI_Barrier(comm);
 
@@ -141,6 +137,10 @@ static void test_partition_planar_cloud(void** state, int nx, int ny)
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
 #endif
+
+  // Clean up.
+  neighbor_pairing_free(pairing);
+  point_cloud_free(cloud);
 }
 
 static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
@@ -191,10 +191,6 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
   silo_file_write_scalar_point_field(silo, "rank", "cloud", p, NULL);
   silo_file_close(silo);
 
-  // Clean up.
-  neighbor_pairing_free(pairing);
-  point_cloud_free(cloud);
-
   // Make sure all processes have written to the file.
   MPI_Barrier(comm);
 
@@ -204,6 +200,10 @@ static void test_partition_cubic_cloud(void** state, int nx, int ny, int nz)
   assert_int_equal(1, num_files);
   assert_int_equal(nprocs, num_procs);
 #endif
+
+  // Clean up.
+  neighbor_pairing_free(pairing);
+  point_cloud_free(cloud);
 }
 
 static void test_partition_small_linear_cloud(void** state)

--- a/model/tests/test_star_stencil.c
+++ b/model/tests/test_star_stencil.c
@@ -126,39 +126,11 @@ static void test_NXxNYxNZ_star_stencil(void** state,
   adj_graph_free(G);
 
   // Create a matrix sparsity from the stencil.
-  matrix_sparsity_t* sp = sparsity_from_stencil(stencil);
+  matrix_sparsity_t* sp = matrix_sparsity_from_stencil(stencil);
   assert_int_equal(matrix_sparsity_num_local_rows(sp), stencil_num_indices(stencil));
   matrix_sparsity_free(sp);
 
-  // Write the stencil to a Silo file.
-  char prefix[FILENAME_MAX+1];
-  if (comm == MPI_COMM_WORLD)
-    snprintf(prefix, FILENAME_MAX, "star_all");
-  else
-  {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    snprintf(prefix, FILENAME_MAX, "star_p%d", rank);
-  }
-  silo_file_t* silo = silo_file_new(comm, prefix, "star", 1, 0, 0, 0.0);
-  silo_file_write_stencil(silo, "stencil", stencil);
-  silo_file_close(silo);
-
-  // Make sure the file is written before we attempt to read it!
-  MPI_Barrier(comm);
-
-  // Read the stencil from the file and check its contents.
-  real_t t;
-  silo = silo_file_open(comm, prefix, "star", 0, 0, &t);
-  assert_true(silo_file_contains_stencil(silo, "stencil"));
-  stencil1 = silo_file_read_stencil(silo, "stencil", comm);
-  silo_file_close(silo);
-  check_stencil(state, mesh, nx, ny, nz, 
-                num_interior_neighbors, num_boundary_neighbors,
-                num_edge_neighbors, num_corner_neighbors,
-                stencil1);
-  stencil_free(stencil1);
-
+  // Clean up.
   stencil_free(stencil);
   polymesh_free(mesh);
 }

--- a/mpi_serial/mpi.h
+++ b/mpi_serial/mpi.h
@@ -100,6 +100,7 @@ int MPI_Send(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI
 int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
 int MPI_Isend(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
 int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Ssend(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 int MPI_Send_init(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
 int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
 int MPI_Irsend(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);

--- a/mpi_serial/mpi_serial.c
+++ b/mpi_serial/mpi_serial.c
@@ -203,6 +203,11 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag, 
   return MPI_SUCCESS;
 }
 
+int MPI_Ssend(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm)
+{
+  return MPI_SUCCESS;
+}
+
 int MPI_Send_init(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request)
 {
   return MPI_SUCCESS;


### PR DESCRIPTION
This function allows a developer to implement a program for remapping old save files to different numbers of processors. A process can read in a file from another process in a given communicator, dealing with the data in arbitrary ways. This "less is more" approach provides a mechanism without complicating everything that already  exists.

Fixes #215 