### PR TITLE
Field metadata

### DIFF
--- a/core/lua_core.c
+++ b/core/lua_core.c
@@ -920,28 +920,28 @@ static int st2_new(lua_State* L)
   real_t yy = lua_to_real(L, 4);
   real_t yz = lua_to_real(L, 5);
   real_t zz = lua_to_real(L, 6);
-  sym_tensor2_t* t = sym_tensor2_new(xx, xy, xz,
-                                         yy, yz,
-                                             zz);
-  lua_push_sym_tensor2(L, t);
+  symtensor2_t* t = symtensor2_new(xx, xy, xz,
+                                       yy, yz,
+                                           zz);
+  lua_push_symtensor2(L, t);
   return 1;
 }
 
-static lua_module_function sym_tensor2_funcs[] = {
-  {"new", st2_new, "sym_tensor2.new(txx, txy, txz, tyy, tyz, tzz) -> new symmetric rank 2 tensor."},
+static lua_module_function symtensor2_funcs[] = {
+  {"new", st2_new, "symtensor2.new(txx, txy, txz, tyy, tyz, tzz) -> new symmetric rank 2 tensor."},
   {NULL, NULL, NULL}
 };
 
 static int st2_xx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->xx);
   return 1;
 }
 
 static int st2_set_xx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->xx = lua_to_real(L, 2);
@@ -950,14 +950,14 @@ static int st2_set_xx(lua_State* L)
 
 static int st2_xy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->xy);
   return 1;
 }
 
 static int st2_set_xy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->xy = lua_to_real(L, 2);
@@ -966,14 +966,14 @@ static int st2_set_xy(lua_State* L)
 
 static int st2_xz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->xz);
   return 1;
 }
 
 static int st2_set_xz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->xz = lua_to_real(L, 2);
@@ -982,14 +982,14 @@ static int st2_set_xz(lua_State* L)
 
 static int st2_yx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->xy);
   return 1;
 }
 
 static int st2_set_yx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->xy = lua_to_real(L, 2);
@@ -998,14 +998,14 @@ static int st2_set_yx(lua_State* L)
 
 static int st2_yy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->yy);
   return 1;
 }
 
 static int st2_set_yy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->yy = lua_to_real(L, 2);
@@ -1014,14 +1014,14 @@ static int st2_set_yy(lua_State* L)
 
 static int st2_yz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->yz);
   return 1;
 }
 
 static int st2_set_yz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->yz = lua_to_real(L, 2);
@@ -1030,14 +1030,14 @@ static int st2_set_yz(lua_State* L)
 
 static int st2_zx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->xz);
   return 1;
 }
 
 static int st2_set_zx(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->xz = lua_to_real(L, 2);
@@ -1046,14 +1046,14 @@ static int st2_set_zx(lua_State* L)
 
 static int st2_zy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->yz);
   return 1;
 }
 
 static int st2_set_zy(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->yz = lua_to_real(L, 2);
@@ -1062,21 +1062,21 @@ static int st2_set_zy(lua_State* L)
 
 static int st2_zz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   lua_pushnumber(L, (double)t->zz);
   return 1;
 }
 
 static int st2_set_zz(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (!lua_isnumber(L, 2))
     return luaL_error(L, "Tensor components must be numbers.");
   t->zz = lua_to_real(L, 2);
   return 0;
 }
 
-static lua_class_field sym_tensor2_fields[] = {
+static lua_class_field symtensor2_fields[] = {
   {"xx", st2_xx, st2_set_xx},
   {"xy", st2_xy, st2_set_xy},
   {"xz", st2_xz, st2_set_xz},
@@ -1091,66 +1091,66 @@ static lua_class_field sym_tensor2_fields[] = {
 
 static int st2_add(lua_State* L)
 {
-  sym_tensor2_t* t1 = lua_to_sym_tensor2(L, 1);
-  sym_tensor2_t* t2 = lua_to_sym_tensor2(L, 2);
+  symtensor2_t* t1 = lua_to_symtensor2(L, 1);
+  symtensor2_t* t2 = lua_to_symtensor2(L, 2);
   if ((t1 == NULL) || (t2 == NULL))
-    luaL_error(L, "Arguments must both be sym_tensor2s.");
-  sym_tensor2_t* sum = sym_tensor2_new(t1->xx + t2->xx, t1->xy + t2->xy, t1->xz + t2->xz,
-                                                        t1->yy + t2->yy, t1->yz + t2->yz,
-                                                                         t1->zz + t2->zz);
-  lua_push_sym_tensor2(L, sum);
+    luaL_error(L, "Arguments must both be symtensor2s.");
+  symtensor2_t* sum = symtensor2_new(t1->xx + t2->xx, t1->xy + t2->xy, t1->xz + t2->xz,
+                                                      t1->yy + t2->yy, t1->yz + t2->yz,
+                                                                       t1->zz + t2->zz);
+  lua_push_symtensor2(L, sum);
   return 1;
 }
 
 static int st2_sub(lua_State* L)
 {
-  sym_tensor2_t* t1 = lua_to_sym_tensor2(L, 1);
-  sym_tensor2_t* t2 = lua_to_sym_tensor2(L, 2);
+  symtensor2_t* t1 = lua_to_symtensor2(L, 1);
+  symtensor2_t* t2 = lua_to_symtensor2(L, 2);
   if ((t1 == NULL) || (t2 == NULL))
-    luaL_error(L, "Arguments must both be sym_tensor2s.");
-  sym_tensor2_t* diff = sym_tensor2_new(t1->xx - t2->xx, t1->xy - t2->xy, t1->xz - t2->xz,
-                                                         t1->yy - t2->yy, t1->yz - t2->yz,
-                                                         t1->zz - t2->zz);
-  lua_push_sym_tensor2(L, diff);
+    luaL_error(L, "Arguments must both be symtensor2s.");
+  symtensor2_t* diff = symtensor2_new(t1->xx - t2->xx, t1->xy - t2->xy, t1->xz - t2->xz,
+                                                       t1->yy - t2->yy, t1->yz - t2->yz,
+                                                                        t1->zz - t2->zz);
+  lua_push_symtensor2(L, diff);
   return 1;
 }
 
 static int st2_mul(lua_State* L)
 {
-  if ((!lua_isnumber(L, 1) || !lua_is_sym_tensor2(L, 2)) &&
-      (!lua_is_sym_tensor2(L, 1) || !lua_isnumber(L, 2)))
-    luaL_error(L, "Arguments must be a sym_tensor2 and a number.");
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, (lua_isnumber(L, 1)) ? 2 : 1);
+  if ((!lua_isnumber(L, 1) || !lua_is_symtensor2(L, 2)) &&
+      (!lua_is_symtensor2(L, 1) || !lua_isnumber(L, 2)))
+    luaL_error(L, "Arguments must be a symtensor2 and a number.");
+  symtensor2_t* t = lua_to_symtensor2(L, (lua_isnumber(L, 1)) ? 2 : 1);
   real_t c = lua_to_real(L, (lua_isnumber(L, 1)) ? 1 : 2);
-  sym_tensor2_t* t1 = sym_tensor2_new(c * t->xx, c * t->xy, c * t->xz,
-                                                 c * t->yy, c * t->yz,
-                                                            c * t->zz);
-  lua_push_sym_tensor2(L, t1);
+  symtensor2_t* t1 = symtensor2_new(c * t->xx, c * t->xy, c * t->xz,
+                                               c * t->yy, c * t->yz,
+                                                          c * t->zz);
+  lua_push_symtensor2(L, t1);
   return 1;
 }
 
 static int st2_div(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
   if (t == NULL)
-    luaL_error(L, "Argument 1 must be a sym_tensor2.");
+    luaL_error(L, "Argument 1 must be a symtensor2.");
   if (!lua_isnumber(L, 2))
     luaL_error(L, "Argument 2 must be a number.");
   real_t c = lua_to_real(L, 2);
-  sym_tensor2_t* t1 = sym_tensor2_new(t->xx/c, t->xy/c, t->xz/c,
-                                               t->yy/c, t->yz/c,
-                                                        t->zz/c);
-  lua_push_sym_tensor2(L, t1);
+  symtensor2_t* t1 = symtensor2_new(t->xx/c, t->xy/c, t->xz/c,
+                                             t->yy/c, t->yz/c,
+                                                      t->zz/c);
+  lua_push_symtensor2(L, t1);
   return 1;
 }
 
 static int st2_unm(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
-  sym_tensor2_t* t1 = sym_tensor2_new(-1.0 * t->xx, -1.0 * t->xy, -1.0 * t->xz,
-                                                    -1.0 * t->yy, -1.0 * t->yz,
-                                                                  -1.0 * t->zz);
-  lua_push_sym_tensor2(L, t1);
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
+  symtensor2_t* t1 = symtensor2_new(-1.0 * t->xx, -1.0 * t->xy, -1.0 * t->xz,
+                                                  -1.0 * t->yy, -1.0 * t->yz,
+                                                                -1.0 * t->zz);
+  lua_push_symtensor2(L, t1);
   return 1;
 }
 
@@ -1162,13 +1162,13 @@ static int st2_len(lua_State* L)
 
 static int st2_tostring(lua_State* L)
 {
-  sym_tensor2_t* t = lua_to_sym_tensor2(L, 1);
-  lua_pushfstring(L, "sym_tensor2((%f, %f, %f), (%f, %f, %f), (%f, %f, %f))", 
+  symtensor2_t* t = lua_to_symtensor2(L, 1);
+  lua_pushfstring(L, "symtensor2((%f, %f, %f), (%f, %f, %f), (%f, %f, %f))", 
                   t->xx, t->xy, t->xz, t->xy, t->yy, t->yz, t->xz, t->yz, t->zz);
   return 1;
 }
 
-static lua_class_method sym_tensor2_methods[] = {
+static lua_class_method symtensor2_methods[] = {
   {"__add", st2_add, NULL},
   {"__sub", st2_sub, NULL},
   {"__mul", st2_mul, NULL},
@@ -2212,11 +2212,11 @@ static int lua_register_constants(lua_State* L)
   lua_setfield(L, -2, "unit");
   lua_pop(L, 1);
 
-  lua_getglobal(L, "sym_tensor2");
-  sym_tensor2_t I_sym = {.xx = 1.0, .xy = 0.0, .xz = 0.0,
+  lua_getglobal(L, "symtensor2");
+  symtensor2_t I_sym = {.xx = 1.0, .xy = 0.0, .xz = 0.0,
                                     .yy = 1.0, .yz = 0.0,
                                                .zz = 1.0};
-  lua_push_sym_tensor2(L, &I_sym);
+  lua_push_symtensor2(L, &I_sym);
   lua_setfield(L, -2, "unit");
   lua_pop(L, 1);
 
@@ -2496,7 +2496,7 @@ int lua_register_core_modules(lua_State* L)
   lua_register_class(L, "point2", "A 2D point.", point2_funcs, point2_fields, point2_methods, NULL);
   lua_register_class(L, "vector", "A 3D vector.", vector_funcs, vector_fields, vector_methods, NULL);
   lua_register_class(L, "tensor2", "A general rank 2 tensor.", tensor2_funcs, tensor2_fields, tensor2_methods, NULL);
-  lua_register_class(L, "sym_tensor2", "A symmetric rank 2 tensor.", sym_tensor2_funcs, sym_tensor2_fields, sym_tensor2_methods, NULL);
+  lua_register_class(L, "symtensor2", "A symmetric rank 2 tensor.", symtensor2_funcs, symtensor2_fields, symtensor2_methods, NULL);
   lua_register_array(L);
   lua_register_ndarray(L);
   lua_register_constants(L);
@@ -2612,19 +2612,19 @@ tensor2_t* lua_to_tensor2(lua_State* L, int index)
   return (tensor2_t*)lua_to_object(L, index, "tensor2");
 }
 
-void lua_push_sym_tensor2(lua_State* L, sym_tensor2_t* t)
+void lua_push_symtensor2(lua_State* L, symtensor2_t* t)
 {
-  lua_push_object(L, "sym_tensor2", t);
+  lua_push_object(L, "symtensor2", t);
 }
 
-bool lua_is_sym_tensor2(lua_State* L, int index)
+bool lua_is_symtensor2(lua_State* L, int index)
 {
-  return lua_is_object(L, index, "sym_tensor2");
+  return lua_is_object(L, index, "symtensor2");
 }
 
-sym_tensor2_t* lua_to_sym_tensor2(lua_State* L, int index)
+symtensor2_t* lua_to_symtensor2(lua_State* L, int index)
 {
-  return (sym_tensor2_t*)lua_to_object(L, index, "sym_tensor2");
+  return (symtensor2_t*)lua_to_object(L, index, "symtensor2");
 }
 
 void lua_push_mpi_comm(lua_State* L, MPI_Comm comm)

--- a/core/lua_core.h
+++ b/core/lua_core.h
@@ -101,15 +101,15 @@ bool lua_is_tensor2(lua_State* L, int index);
 tensor2_t* lua_to_tensor2(lua_State* L, int index);
 
 /// Pushes a (3D) symmetric rank-2 tensor t onto L's stack.
-void lua_push_sym_tensor2(lua_State* L, sym_tensor2_t* t);
+void lua_push_symtensor2(lua_State* L, symtensor2_t* t);
 
 /// Returns true if the item at the given index on L's stack is a symmetric 
 /// rank-2 tensor, false if not.
-bool lua_is_sym_tensor2(lua_State* L, int index);
+bool lua_is_symtensor2(lua_State* L, int index);
 
 /// Returns the symmetric rank-2 tensor at the given index on L's stack, or 
 /// NULL if the item there is not a symmetric rank-2 tensor.
-sym_tensor2_t* lua_to_sym_tensor2(lua_State* L, int index);
+symtensor2_t* lua_to_symtensor2(lua_State* L, int index);
 
 /// Pushes an MPI communicator onto L's stack.
 void lua_push_mpi_comm(lua_State* L, MPI_Comm comm);
@@ -137,7 +137,7 @@ typedef enum
   LUA_ARRAY_POINT,       // 3D points
   LUA_ARRAY_VECTOR,      // 3D vectors
   LUA_ARRAY_TENSOR2,     // 3D rank-2 tensors
-  LUA_ARRAY_SYM_TENSOR2  // 3D symmetric rank-2 tensors
+  LUA_ARRAY_SYMTENSOR2   // 3D symmetric rank-2 tensors
 } lua_array_data_t;
 
 /// Pushes an array of the given type onto L's stack. If free_data is true, 

--- a/core/tensor2.c
+++ b/core/tensor2.c
@@ -24,16 +24,16 @@ void tensor2_fprintf(tensor2_t* t, FILE* stream)
   fprintf(stream, "[%g, %g, %g]\n", t->zx, t->zy, t->zz);
 }
 
-sym_tensor2_t* sym_tensor2_new(real_t xx, real_t xy, real_t xz,
-                                          real_t yy, real_t yz,
-                                                     real_t zz)
+symtensor2_t* symtensor2_new(real_t xx, real_t xy, real_t xz,
+                                        real_t yy, real_t yz,
+                                                   real_t zz)
 {
-  sym_tensor2_t* t = polymec_refcounted_malloc(sizeof(sym_tensor2_t), NULL);
-  sym_tensor2_set(t, xx, xy, xz, yy, yz, zz);
+  symtensor2_t* t = polymec_refcounted_malloc(sizeof(symtensor2_t), NULL);
+  symtensor2_set(t, xx, xy, xz, yy, yz, zz);
   return t;
 }
 
-void sym_tensor2_get_eigenvalues(sym_tensor2_t* t, real_t eigenvalues[3])
+void symtensor2_get_eigenvalues(symtensor2_t* t, real_t eigenvalues[3])
 {
   char jobz = 'N', uplo = 'L';
   int N = 3, lda = 3, lwork = 5*3, info;
@@ -43,7 +43,7 @@ void sym_tensor2_get_eigenvalues(sym_tensor2_t* t, real_t eigenvalues[3])
   ASSERT(info == 0);
 }
 
-void sym_tensor2_get_eigenvectors(sym_tensor2_t* t, real_t eigenvalues[3], vector_t eigenvectors[3])
+void symtensor2_get_eigenvectors(symtensor2_t* t, real_t eigenvalues[3], vector_t eigenvectors[3])
 {
   char jobz = 'V', uplo = 'L';
   int N = 3, lda = 3, lwork = 5*3, info;
@@ -62,7 +62,7 @@ void sym_tensor2_get_eigenvectors(sym_tensor2_t* t, real_t eigenvalues[3], vecto
   eigenvectors[2].z = A[8];
 }
 
-void sym_tensor2_fprintf(sym_tensor2_t* t, FILE* stream)
+void symtensor2_fprintf(symtensor2_t* t, FILE* stream)
 {
   fprintf(stream, "[%g, %g, %g]\n", t->xx, t->xy, t->xz);
   fprintf(stream, "[%g, %g, %g]\n", t->xy, t->yy, t->yz);

--- a/core/tensor2.h
+++ b/core/tensor2.h
@@ -137,7 +137,7 @@ static inline void tensor2_invert(tensor2_t* t, tensor2_t* t_inverse)
 /// \memberof tensor2
 void tensor2_fprintf(tensor2_t* t, FILE* stream);
 
-/// \class sym_tensor2
+/// \class symtensor2
 /// A rank-2 symmetric tensor in 3D space. You can cast this to and from an 
 /// array of 6 real_t. Not castable to any Fortran matrix type.
 typedef struct
@@ -145,29 +145,29 @@ typedef struct
   real_t xx, xy, xz,
              yy, yz,
                  zz;
-} sym_tensor2_t;
+} symtensor2_t;
 
 /// Allocates a new symmetric tensor2 on the heap with the given components. Not 
 /// necessary if you are allocating a symmetric tensor2 on the stack. 
-/// \memberof sym_tensor2
+/// \memberof symtensor2
 /// \refcounted
-sym_tensor2_t* sym_tensor2_new(real_t xx, real_t xy, real_t xz,
-                                          real_t yy, real_t yz,
-                                                     real_t zz);
+symtensor2_t* symtensor2_new(real_t xx, real_t xy, real_t xz,
+                                        real_t yy, real_t yz,
+                                                   real_t zz);
 
 /// Copies symmetric tensor components from src to dest.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_copy(sym_tensor2_t* src, sym_tensor2_t* dest)
+/// \memberof symtensor2
+static inline void symtensor2_copy(symtensor2_t* src, symtensor2_t* dest)
 {
   memcpy(dest, src, 6*sizeof(real_t));
 }
 
 /// Sets the components of the given symmetric tensor.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_set(sym_tensor2_t* t, 
-                                   real_t xx, real_t xy, real_t xz, 
-                                              real_t yy, real_t yz,
-                                                         real_t zz)
+/// \memberof symtensor2
+static inline void symtensor2_set(symtensor2_t* t, 
+                                  real_t xx, real_t xy, real_t xz, 
+                                             real_t yy, real_t yz,
+                                                        real_t zz)
 {
   t->xx = xx; t->xy = xy; t->xz = xz;
               t->yy = yy; t->yz = yz;
@@ -176,8 +176,8 @@ static inline void sym_tensor2_set(sym_tensor2_t* t,
 
 /// Sets the given symmetric tensor to a 3x3 identity tensor scaled by 
 /// the given factor.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_set_identity(sym_tensor2_t* t, real_t factor)
+/// \memberof symtensor2
+static inline void symtensor2_set_identity(symtensor2_t* t, real_t factor)
 {
   t->xx = factor; t->xy = 0.0;    t->xz = 0.0;
                   t->yy = factor; t->yz = 0.0;
@@ -185,8 +185,8 @@ static inline void sym_tensor2_set_identity(sym_tensor2_t* t, real_t factor)
 }
 
 /// Scales the components of the given symmetric tensor.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_scale(sym_tensor2_t* t, real_t factor)
+/// \memberof symtensor2
+static inline void symtensor2_scale(symtensor2_t* t, real_t factor)
 {
   t->xx *= factor; t->xy *= factor; t->xz *= factor;
                    t->yy *= factor; t->yz *= factor;
@@ -194,8 +194,8 @@ static inline void sym_tensor2_scale(sym_tensor2_t* t, real_t factor)
 }
 
 /// Returns the determinant of the symmetric tensor.
-/// \memberof sym_tensor2
-static inline real_t sym_tensor2_det(sym_tensor2_t* t)
+/// \memberof symtensor2
+static inline real_t symtensor2_det(symtensor2_t* t)
 {
   return t->xx * (t->yy*t->zz - t->yz*t->yz) - 
          t->xy * (t->xy*t->zz - t->xz*t->yz) + 
@@ -203,15 +203,15 @@ static inline real_t sym_tensor2_det(sym_tensor2_t* t)
 }
 
 /// Returns the trace of the symmetric tensor.
-/// \memberof sym_tensor2
-static inline real_t sym_tensor2_trace(sym_tensor2_t* t)
+/// \memberof symtensor2
+static inline real_t symtensor2_trace(symtensor2_t* t)
 {
   return t->xx + t->yy + t->zz;
 }
 
 /// Computes the (vector-valued) symmetric-tensor-vector product.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_dot_vector(sym_tensor2_t* t, vector_t* v, vector_t* tv)
+/// \memberof symtensor2
+static inline void symtensor2_dot_vector(symtensor2_t* t, vector_t* v, vector_t* tv)
 {
   tv->x = t->xx*v->x + t->xy*v->y + t->xz*v->z;
   tv->y = t->xy*v->x + t->yy*v->y + t->yz*v->z;
@@ -219,20 +219,20 @@ static inline void sym_tensor2_dot_vector(sym_tensor2_t* t, vector_t* v, vector_
 }
 
 /// Computes the double dot product x dot t dot y.
-/// \memberof sym_tensor2
-static inline real_t sym_tensor2_ddot(sym_tensor2_t* t, vector_t* x, vector_t* y)
+/// \memberof symtensor2
+static inline real_t symtensor2_ddot(symtensor2_t* t, vector_t* x, vector_t* y)
 {
   vector_t ty;
-  sym_tensor2_dot_vector(t, y, &ty);
+  symtensor2_dot_vector(t, y, &ty);
   return vector_dot(x, &ty);
 }
 
 /// Computes the inverse of the symmetric tensor.
-/// \memberof sym_tensor2
-static inline void sym_tensor2_invert(sym_tensor2_t* t, sym_tensor2_t* t_inverse)
+/// \memberof symtensor2
+static inline void symtensor2_invert(symtensor2_t* t, symtensor2_t* t_inverse)
 {
 #ifndef NDEBUG
-  real_t det_t = sym_tensor2_det(t);
+  real_t det_t = symtensor2_det(t);
   ASSERT(!reals_equal(det_t, 0.0));
 #endif
   t_inverse->xx = t->yy*t->zz - t->yz*t->yz;
@@ -245,26 +245,26 @@ static inline void sym_tensor2_invert(sym_tensor2_t* t, sym_tensor2_t* t_inverse
 
 /// Computes the 3 eigenvalues of the symmetric tensor, storing them in 
 /// the given array in ascending order.
-/// \memberof sym_tensor2
-void sym_tensor2_get_eigenvalues(sym_tensor2_t* t, real_t eigenvalues[3]);
+/// \memberof symtensor2
+void symtensor2_get_eigenvalues(symtensor2_t* t, real_t eigenvalues[3]);
 
 /// Computes the 3 eigenvalues and eigenvectors of the symmetric tensor, 
 /// storing the former as scalars in the given array and the later as 
 /// vectors in the array eigenvectors.
-/// \memberof sym_tensor2
-void sym_tensor2_get_eigenvectors(sym_tensor2_t* t, 
-                                  real_t eigenvalues[3], 
-                                  vector_t eigenvectors[3]);
+/// \memberof symtensor2
+void symtensor2_get_eigenvectors(symtensor2_t* t, 
+                                 real_t eigenvalues[3], 
+                                 vector_t eigenvectors[3]);
 
 /// Writes a text representation of the symmetric tensor to the given stream.
-/// \memberof sym_tensor2
-void sym_tensor2_fprintf(sym_tensor2_t* t, FILE* stream);
+/// \memberof symtensor2
+void symtensor2_fprintf(symtensor2_t* t, FILE* stream);
 
 ///@}
 
 // Arrays of tensors.
 DEFINE_ARRAY(tensor2_array, tensor2_t)
-DEFINE_ARRAY(sym_tensor2_array, sym_tensor2_t)
+DEFINE_ARRAY(symtensor2_array, symtensor2_t)
 
 #endif
 

--- a/core/tests/test_core_driver.input
+++ b/core/tests/test_core_driver.input
@@ -72,8 +72,8 @@ t1.zx = 7
 t1.zy = 8
 t1.zz = 9
 
-st1 = sym_tensor2.new(1,2,3,4,5,6)
-st2 = sym_tensor2.new(6,5,4,3,2,1)
+st1 = symtensor2.new(1,2,3,4,5,6)
+st2 = symtensor2.new(6,5,4,3,2,1)
 print(st1)
 print(st1+st2)
 print(st1-st2)
@@ -208,14 +208,14 @@ a = array.new({tensor2.new(0,0,0,0,0,0,0,0,0), tensor2.new(1,1,1,1,1,1,1,1,1), t
 a[1] = tensor2.new(1,1,1,1,1,1,1,1,1)
 a = a .. a
 print(a)
-a = array.new({sym_tensor2.new(0,0,0,0,0,0), sym_tensor2.new(1,1,1,1,1,1), sym_tensor2.new(2,2,2,2,2,2)}, 'sym_tensor2')
-a[1] = sym_tensor2.new(1,1,1,1,1,1)
+a = array.new({symtensor2.new(0,0,0,0,0,0), symtensor2.new(1,1,1,1,1,1), symtensor2.new(2,2,2,2,2,2)}, 'symtensor2')
+a[1] = symtensor2.new(1,1,1,1,1,1)
 a = a .. a
 print(a)
 
 -- Multidimensional arrays.
 for i, t in ipairs({'byte', 'int', 'int64', 'uint64', 'index', 'real', 'complex', 
-                    'point', 'vector', 'tensor2', 'sym_tensor2'}) do
+                    'point', 'vector', 'tensor2', 'symtensor2'}) do
   a = ndarray.new({10,10}, t)
   print(a)
 end

--- a/core/tests/test_kd_tree.c
+++ b/core/tests/test_kd_tree.c
@@ -119,10 +119,10 @@ static void test_within_radius(void** state)
 // Returns true if y is in the given ellipse centered at x.
 static bool point_in_ellipse(void* context, point_t* x, point_t* y)
 {
-  sym_tensor2_t* E = context;
+  symtensor2_t* E = context;
   vector_t d;
   point_displacement(x, y, &d);
-  return (sym_tensor2_ddot(E, &d, &d) < 1.0);
+  return (symtensor2_ddot(E, &d, &d) < 1.0);
 }
 
 static void test_within_ellipse(void** state) 
@@ -138,7 +138,7 @@ static void test_within_ellipse(void** state)
 
   // Now use a predicate query and compare it to the results of a brute force 
   // calculation.
-  sym_tensor2_t E = {0.2, 0.0, 0.0, 
+  symtensor2_t E = {0.2, 0.0, 0.0, 
                           0.3, 0.0,
                                0.4};
   for (int i = 0; i < 10; ++i) // 10 queries.

--- a/core/tests/test_tensor2.c
+++ b/core/tests/test_tensor2.c
@@ -147,23 +147,23 @@ static void test_tensor2_array(void** state)
   tensor2_array_free(a);
 }
 
-static void test_sym_tensor2_ctor(void** state)
+static void test_symtensor2_ctor(void** state)
 {
-  sym_tensor2_t* t = sym_tensor2_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  symtensor2_t* t = symtensor2_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
   assert_true(reals_equal(t->xx, 1.0));
   assert_true(reals_equal(t->xy, 2.0));
   assert_true(reals_equal(t->xz, 3.0));
   assert_true(reals_equal(t->yy, 4.0));
   assert_true(reals_equal(t->yz, 5.0));
   assert_true(reals_equal(t->zz, 6.0));
-  sym_tensor2_fprintf(t, stdout);
+  symtensor2_fprintf(t, stdout);
   t = NULL;
 }
 
-static void test_sym_tensor2_set(void** state)
+static void test_symtensor2_set(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  symtensor2_t t;
+  symtensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
   assert_true(reals_equal(t.xx, 1.0));
   assert_true(reals_equal(t.xy, 2.0));
   assert_true(reals_equal(t.xz, 3.0));
@@ -172,10 +172,10 @@ static void test_sym_tensor2_set(void** state)
   assert_true(reals_equal(t.zz, 6.0));
 }
 
-static void test_sym_tensor2_set_identity(void** state)
+static void test_symtensor2_set_identity(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set_identity(&t, 5.0);
+  symtensor2_t t;
+  symtensor2_set_identity(&t, 5.0);
   assert_true(reals_equal(t.xx, 5.0));
   assert_true(reals_equal(t.xy, 0.0));
   assert_true(reals_equal(t.xz, 0.0));
@@ -184,11 +184,11 @@ static void test_sym_tensor2_set_identity(void** state)
   assert_true(reals_equal(t.zz, 5.0));
 }
 
-static void test_sym_tensor2_scale(void** state)
+static void test_symtensor2_scale(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-  sym_tensor2_scale(&t, 2.0);
+  symtensor2_t t;
+  symtensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  symtensor2_scale(&t, 2.0);
   assert_true(reals_equal(t.xx, 2.0));
   assert_true(reals_equal(t.xy, 4.0));
   assert_true(reals_equal(t.xz, 6.0));
@@ -197,41 +197,41 @@ static void test_sym_tensor2_scale(void** state)
   assert_true(reals_equal(t.zz, 12.0));
 }
 
-static void test_sym_tensor2_det(void** state)
+static void test_symtensor2_det(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-  real_t det_t = sym_tensor2_det(&t);
+  symtensor2_t t;
+  symtensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  real_t det_t = symtensor2_det(&t);
   assert_true(reals_equal(det_t, 1.0 * (4.0*6.0-5.0*5.0) - 2.0 * (2.0*6.0-3.0*5.0) + 3.0 * (2.0*5.0-3.0*4.0)));
 }
 
-static void test_sym_tensor2_trace(void** state)
+static void test_symtensor2_trace(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-  real_t trace_t = sym_tensor2_trace(&t);
+  symtensor2_t t;
+  symtensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  real_t trace_t = symtensor2_trace(&t);
   assert_true(reals_equal(trace_t, 1.0 + 4.0 + 6.0));
 }
 
-static void test_sym_tensor2_dot_vector(void** state)
+static void test_symtensor2_dot_vector(void** state)
 {
-  sym_tensor2_t t;
-  sym_tensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  symtensor2_t t;
+  symtensor2_set(&t, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
   vector_t v = {.x = 1.0, .y = 2.0, .z = 3.0};
   vector_t t_o_v;
-  sym_tensor2_dot_vector(&t, &v, &t_o_v);
+  symtensor2_dot_vector(&t, &v, &t_o_v);
   assert_true(reals_equal(t_o_v.x, 14.0));
   assert_true(reals_equal(t_o_v.y, 25.0));
   assert_true(reals_equal(t_o_v.z, 31.0));
 }
 
-static void test_sym_tensor2_invert(void** state)
+static void test_symtensor2_invert(void** state)
 {
-  sym_tensor2_t A, Ainv;
-  sym_tensor2_set(&A, 1.0, 1.0, 1.0, 
+  symtensor2_t A, Ainv;
+  symtensor2_set(&A, 1.0, 1.0, 1.0, 
                            2.0, 2.0,
                                 3.0);
-  sym_tensor2_invert(&A, &Ainv);
+  symtensor2_invert(&A, &Ainv);
   assert_true(reals_nearly_equal(Ainv.xx, 2.0, 1e-14));
   assert_true(reals_nearly_equal(Ainv.xy, -1.0, 1e-14));
   assert_true(reals_nearly_equal(Ainv.xz, 0.0, 1e-14));
@@ -240,14 +240,14 @@ static void test_sym_tensor2_invert(void** state)
   assert_true(reals_nearly_equal(Ainv.zz, 1.0, 1e-14));
 }
 
-static void test_sym_tensor2_get_eigenvalues(void** state)
+static void test_symtensor2_get_eigenvalues(void** state)
 {
-  sym_tensor2_t A;
-  sym_tensor2_set(&A, 2.0, 0.0, 1.0, 
+  symtensor2_t A;
+  symtensor2_set(&A, 2.0, 0.0, 1.0, 
                            2.0, 0.0,
                                 2.0);
   real_t lambdas[3];
-  sym_tensor2_get_eigenvalues(&A, lambdas);
+  symtensor2_get_eigenvalues(&A, lambdas);
   assert_true(reals_nearly_equal(lambdas[0], 1.0, 1e-14));
   assert_true(reals_nearly_equal(lambdas[1], 2.0, 1e-14));
   assert_true(reals_nearly_equal(lambdas[2], 3.0, 1e-14));
@@ -255,24 +255,24 @@ static void test_sym_tensor2_get_eigenvalues(void** state)
 
 // This helper returns true if u is an eigenvector of A corresponding to 
 // the eigenvalue lambda, false if not.
-static bool is_eigenvector(sym_tensor2_t* A, real_t lambda, vector_t* u)
+static bool is_eigenvector(symtensor2_t* A, real_t lambda, vector_t* u)
 {
   vector_t Au;
-  sym_tensor2_dot_vector(A, u, &Au);
+  symtensor2_dot_vector(A, u, &Au);
   return (reals_nearly_equal(Au.x, lambda*u->x, 1e-14) &&
           reals_nearly_equal(Au.y, lambda*u->y, 1e-14) &&
           reals_nearly_equal(Au.z, lambda*u->z, 1e-14));
 }
 
-static void test_sym_tensor2_get_eigenvectors(void** state)
+static void test_symtensor2_get_eigenvectors(void** state)
 {
-  sym_tensor2_t A;
-  sym_tensor2_set(&A, 2.0, 0.0, 1.0, 
+  symtensor2_t A;
+  symtensor2_set(&A, 2.0, 0.0, 1.0, 
                            2.0, 0.0,
                                 2.0);
   real_t lambdas[3];
   vector_t us[3];
-  sym_tensor2_get_eigenvectors(&A, lambdas, us);
+  symtensor2_get_eigenvectors(&A, lambdas, us);
   assert_true(reals_nearly_equal(lambdas[0], 1.0, 1e-14));
   assert_true(reals_nearly_equal(lambdas[1], 2.0, 1e-14));
   assert_true(reals_nearly_equal(lambdas[2], 3.0, 1e-14));
@@ -287,16 +287,16 @@ static void test_sym_tensor2_get_eigenvectors(void** state)
               is_eigenvector(&A, lambdas[2], &us[2]));
 }
 
-static void test_sym_tensor2_array(void** state)
+static void test_symtensor2_array(void** state)
 {
-  sym_tensor2_array_t* a = sym_tensor2_array_new();
-  sym_tensor2_t A;
-  sym_tensor2_set(&A, 2.0, 0.0, 1.0, 
+  symtensor2_array_t* a = symtensor2_array_new();
+  symtensor2_t A;
+  symtensor2_set(&A, 2.0, 0.0, 1.0, 
                            2.0, 0.0,
                                 2.0);
   for (size_t i = 0; i < 10; ++i)
-    sym_tensor2_array_append(a, A);
-  sym_tensor2_array_free(a);
+    symtensor2_array_append(a, A);
+  symtensor2_array_free(a);
 }
 
 int main(int argc, char* argv[]) 
@@ -314,17 +314,17 @@ int main(int argc, char* argv[])
     cmocka_unit_test(test_tensor2_dot_vector_t),
     cmocka_unit_test(test_tensor2_invert),
     cmocka_unit_test(test_tensor2_array),
-    cmocka_unit_test(test_sym_tensor2_ctor),
-    cmocka_unit_test(test_sym_tensor2_set),
-    cmocka_unit_test(test_sym_tensor2_set_identity),
-    cmocka_unit_test(test_sym_tensor2_scale),
-    cmocka_unit_test(test_sym_tensor2_det),
-    cmocka_unit_test(test_sym_tensor2_trace),
-    cmocka_unit_test(test_sym_tensor2_dot_vector),
-    cmocka_unit_test(test_sym_tensor2_invert),
-    cmocka_unit_test(test_sym_tensor2_get_eigenvalues),
-    cmocka_unit_test(test_sym_tensor2_get_eigenvectors),
-    cmocka_unit_test(test_sym_tensor2_array)
+    cmocka_unit_test(test_symtensor2_ctor),
+    cmocka_unit_test(test_symtensor2_set),
+    cmocka_unit_test(test_symtensor2_set_identity),
+    cmocka_unit_test(test_symtensor2_scale),
+    cmocka_unit_test(test_symtensor2_det),
+    cmocka_unit_test(test_symtensor2_trace),
+    cmocka_unit_test(test_symtensor2_dot_vector),
+    cmocka_unit_test(test_symtensor2_invert),
+    cmocka_unit_test(test_symtensor2_get_eigenvalues),
+    cmocka_unit_test(test_symtensor2_get_eigenvectors),
+    cmocka_unit_test(test_symtensor2_array)
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -12,10 +12,9 @@ add_polymec_library(polymec_geometry coord_mapping.c sd_func.c sdt_func.c
                     unimesh_remote_bc.c constant_unimesh_patch_bc.c
                     polymesh.c polymesh_field.c partition_polymesh.c 
                     create_rectilinear_polymesh.c create_uniform_polymesh.c 
-                    crop_polymesh.c
-                    colmesh.c colmesh_field.c planar_polymesh.c
+                    crop_polymesh.c colmesh.c colmesh_field.c planar_polymesh.c
                     create_quad_planar_polymesh.c create_hex_planar_polymesh.c 
-                    lua_geometry.c)
+                    field_metadata.c lua_geometry.c)
 add_dependencies(polymec_geometry all_3rdparty_libs)
 
 set(POLYMEC_LIBRARIES polymec_geometry;${POLYMEC_LIBRARIES} PARENT_SCOPE)

--- a/geometry/colmesh_field.h
+++ b/geometry/colmesh_field.h
@@ -10,6 +10,7 @@
 
 #include "core/declare_nd_array.h"
 #include "geometry/colmesh.h"
+#include "geometry/field_metadata.h"
 
 /// \addtogroup geometry geometry
 ///@{
@@ -100,6 +101,11 @@ void colmesh_field_set_buffer(colmesh_field_t* field,
 /// Copies the data in this field to a destination field.
 /// \memberof colmesh_field
 void colmesh_field_copy(colmesh_field_t* field, colmesh_field_t* dest);
+
+/// Returns the metadata associated with this field. Every field has a 
+/// metadata object that is empty until its properties are specified.
+/// \memberof unimesh_field
+field_metadata_t* colmesh_field_metadata(colmesh_field_t* field);
 
 /// Returns the centering for the field.
 /// \memberof colmesh_field

--- a/geometry/field_metadata.c
+++ b/geometry/field_metadata.c
@@ -82,7 +82,7 @@ field_metadata_t* field_metadata_clone(field_metadata_t* md)
 
 const char* field_metadata_name(field_metadata_t* md, int component)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   return md->names[component];
 }
@@ -91,16 +91,19 @@ void field_metadata_set_name(field_metadata_t* md,
                              int component,
                              const char* name)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   if (md->names[component] != NULL)
     string_free(md->names[component]);
-  md->names[component] = string_dup(name);
+  if (name != NULL)
+    md->names[component] = string_dup(name);
+  else
+    md->names[component] = NULL;
 }
 
 const char* field_metadata_units(field_metadata_t* md, int component)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   return md->units[component];
 }
@@ -109,16 +112,19 @@ void field_metadata_set_units(field_metadata_t* md,
                               int component, 
                               const char* units)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   if (md->units[component] != NULL)
     string_free(md->units[component]);
-  md->units[component] = string_dup(units);
+  if (units != NULL)
+    md->units[component] = string_dup(units);
+  else
+    md->units[component] = NULL;
 }
 
 bool field_metadata_conserved(field_metadata_t* md, int component)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   return md->conserved[component];
 }
@@ -127,14 +133,14 @@ void field_metadata_set_conserved(field_metadata_t* md,
                                   int component,
                                   bool conserved)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   md->conserved[component] = conserved;
 }
 
 bool field_metadata_extensive(field_metadata_t* md, int component)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   return md->extensive[component];
 }
@@ -143,9 +149,14 @@ void field_metadata_set_extensive(field_metadata_t* md,
                                   int component,
                                   bool extensive)
 {
-  ASSERT(component > 0);
+  ASSERT(component >= 0);
   ASSERT(component < md->num_comps);
   md->extensive[component] = extensive;
+}
+
+void field_metadata_set_vector(field_metadata_t* md, int component)
+{
+  md->comp_types[component] = FIELD_VECTOR;
 }
 
 bool field_metadata_has_vectors(field_metadata_t* md)
@@ -175,6 +186,11 @@ bool field_metadata_next_vector(field_metadata_t* md,
     return false;
 }
 
+void field_metadata_set_tensor2(field_metadata_t* md, int component)
+{
+  md->comp_types[component] = FIELD_TENSOR2;
+}
+
 bool field_metadata_has_tensor2s(field_metadata_t* md)
 {
   for (int c = 0; c < md->num_comps; ++c)
@@ -200,6 +216,11 @@ bool field_metadata_next_tensor2(field_metadata_t* md,
   }
   else
     return false;
+}
+
+void field_metadata_set_symtensor2(field_metadata_t* md, int component)
+{
+  md->comp_types[component] = FIELD_SYMTENSOR2;
 }
 
 bool field_metadata_has_symtensor2s(field_metadata_t* md)

--- a/geometry/field_metadata.c
+++ b/geometry/field_metadata.c
@@ -1,0 +1,231 @@
+// Copyright (c) 2012-2019, Jeffrey N. Johnson
+// All rights reserved.
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "core/polymec.h"
+#include "geometry/field_metadata.h"
+
+// Tensor types for field components.
+typedef enum
+{
+  FIELD_UNDEFINED = 0,
+  FIELD_VECTOR = 1,
+  FIELD_TENSOR2 = 2,
+  FIELD_SYMTENSOR2 = 3
+} field_comp_type_t;
+
+struct field_metadata_t
+{
+  // Number of field components.
+  int num_comps;
+  // Component names.
+  char** names; 
+  // Component units.
+  char** units; 
+  // Component conserved quantity flags.
+  bool* conserved; 
+  // Component extensive quantity flags.
+  bool* extensive; 
+  // Component types.
+  field_comp_type_t* comp_types; 
+};
+
+static void field_metadata_free(void* context)
+{
+  field_metadata_t* md = context;
+  for (int c = 0; c < md->num_comps; ++c)
+  {
+    if (md->names[c] != NULL)
+      string_free(md->names[c]);
+    if (md->units[c] != NULL)
+      string_free(md->units[c]);
+  }
+  polymec_free(md->names);
+  polymec_free(md->units);
+  polymec_free(md->conserved);
+  polymec_free(md->extensive);
+  polymec_free(md->comp_types);
+}
+
+field_metadata_t* field_metadata_new(int num_comps)
+{
+  ASSERT(num_comps > 0);
+  field_metadata_t* md = polymec_refcounted_malloc(sizeof(field_metadata_t),
+                                                   field_metadata_free);
+  md->num_comps = num_comps;
+  md->names = polymec_calloc(sizeof(char*) * num_comps);
+  md->units = polymec_calloc(sizeof(char*) * num_comps);
+  md->conserved = polymec_calloc(sizeof(bool) * num_comps);
+  md->extensive = polymec_calloc(sizeof(bool) * num_comps);
+  md->comp_types = polymec_calloc(sizeof(field_comp_type_t) * num_comps);
+  return md;
+}
+
+field_metadata_t* field_metadata_clone(field_metadata_t* md)
+{
+  field_metadata_t* clone = field_metadata_new(md->num_comps);
+  for (int c = 0; c < md->num_comps; ++c)
+  {
+    if (md->names[c] != NULL)
+      clone->names[c] = string_dup(md->names[c]);
+    if (md->units[c] != NULL)
+      clone->units[c] = string_dup(md->units[c]);
+  }
+  memcpy(clone->conserved, md->conserved, sizeof(bool) * md->num_comps);
+  memcpy(clone->extensive, md->extensive, sizeof(bool) * md->num_comps);
+  memcpy(clone->comp_types, md->comp_types, sizeof(field_comp_type_t) * md->num_comps);
+  return clone;
+}
+
+const char* field_metadata_name(field_metadata_t* md, int component)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  return md->names[component];
+}
+
+void field_metadata_set_name(field_metadata_t* md, 
+                             int component,
+                             const char* name)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  if (md->names[component] != NULL)
+    string_free(md->names[component]);
+  md->names[component] = string_dup(name);
+}
+
+const char* field_metadata_units(field_metadata_t* md, int component)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  return md->units[component];
+}
+
+void field_metadata_set_units(field_metadata_t* md, 
+                              int component, 
+                              const char* units)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  if (md->units[component] != NULL)
+    string_free(md->units[component]);
+  md->units[component] = string_dup(units);
+}
+
+bool field_metadata_conserved(field_metadata_t* md, int component)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  return md->conserved[component];
+}
+
+void field_metadata_set_conserved(field_metadata_t* md, 
+                                  int component,
+                                  bool conserved)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  md->conserved[component] = conserved;
+}
+
+bool field_metadata_extensive(field_metadata_t* md, int component)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  return md->extensive[component];
+}
+
+void field_metadata_set_extensive(field_metadata_t* md, 
+                                  int component,
+                                  bool extensive)
+{
+  ASSERT(component > 0);
+  ASSERT(component < md->num_comps);
+  md->extensive[component] = extensive;
+}
+
+bool field_metadata_has_vectors(field_metadata_t* md)
+{
+  for (int c = 0; c < md->num_comps; ++c)
+  {
+    if (md->comp_types[c] == FIELD_VECTOR)
+      return true;
+  }
+  return false;
+}
+
+bool field_metadata_next_vector(field_metadata_t* md,
+                                int* pos,
+                                int* comp)
+{
+  if (*pos >= md->num_comps)
+    return false;
+  while ((md->comp_types[*pos] != FIELD_VECTOR) && (*pos < md->num_comps))
+    ++(*pos);
+  if (md->comp_types[*pos] == FIELD_VECTOR)
+  {
+    *comp = *pos;
+    return true;
+  }
+  else
+    return false;
+}
+
+bool field_metadata_has_tensor2s(field_metadata_t* md)
+{
+  for (int c = 0; c < md->num_comps; ++c)
+  {
+    if (md->comp_types[c] == FIELD_TENSOR2)
+      return true;
+  }
+  return false;
+}
+
+bool field_metadata_next_tensor2(field_metadata_t* md,
+                                 int* pos,
+                                 int* comp)
+{
+  if (*pos >= md->num_comps)
+    return false;
+  while ((md->comp_types[*pos] != FIELD_TENSOR2) && (*pos < md->num_comps))
+    ++(*pos);
+  if (md->comp_types[*pos] == FIELD_TENSOR2)
+  {
+    *comp = *pos;
+    return true;
+  }
+  else
+    return false;
+}
+
+bool field_metadata_has_symtensor2s(field_metadata_t* md)
+{
+  for (int c = 0; c < md->num_comps; ++c)
+  {
+    if (md->comp_types[c] == FIELD_SYMTENSOR2)
+      return true;
+  }
+  return false;
+}
+
+bool field_metadata_next_symtensor2(field_metadata_t* md,
+                                    int* pos,
+                                    int* comp)
+{
+  if (*pos >= md->num_comps)
+    return false;
+  while ((md->comp_types[*pos] != FIELD_SYMTENSOR2) && (*pos < md->num_comps))
+    ++(*pos);
+  if (md->comp_types[*pos] == FIELD_SYMTENSOR2)
+  {
+    *comp = *pos;
+    return true;
+  }
+  else
+    return false;
+}
+

--- a/geometry/field_metadata.h
+++ b/geometry/field_metadata.h
@@ -1,0 +1,150 @@
+// Copyright (c) 2012-2019, Jeffrey N. Johnson
+// All rights reserved.
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef POLYMEC_FIELD_METADATA_H
+#define POLYMEC_FIELD_METADATA_H
+
+/// \addtogroup geometry geometry
+///@{
+
+/// \struct field_metadata_t
+/// This type represents a set of metadata for fields. It stores information
+/// about vectors and tensors that can be used to perform coordinate 
+/// transformations, and it also allows descriptive information to be 
+/// associated with a field.
+/// \refcounted
+typedef struct field_metadata_t field_metadata_t;
+
+/// Creates a new empty object for storing field metadata.
+/// \param [in] num_components The number of components in the associated field.
+/// \memberof field_metadata
+field_metadata_t* field_metadata_new(int num_components);
+
+/// Creates a new copy of the given metadata object.
+/// \param [in] md The metadata object to be cloned.
+/// \memberof field_metadata
+field_metadata_t* field_metadata_clone(field_metadata_t* md);
+
+/// Returns an internal string containing the name of the given component of 
+/// the field, or NULL if the component has no associated name.
+/// \param [in] component The component for which the name is retrieved.
+/// \memberof field_metadata
+const char* field_metadata_name(field_metadata_t* md, int component);
+
+/// Sets the name of the field for the given component of this metadata's
+/// field.
+/// \param [in] component The component of the field to name.
+/// \param [in] name The name to associate with the field.
+/// \memberof field_metadata
+void field_metadata_set_name(field_metadata_t* md, 
+                             int component,
+                             const char* name);
+
+/// Returns an internal string containing the units of the given field 
+/// component, or NULL if the field component has no associated units.
+/// \param [in] component The component for which the units are retrieved.
+/// \memberof field_metadata
+const char* field_metadata_units(field_metadata_t* md, int component);
+
+/// Sets the name of the given component of this metadata's field.
+/// \param [in] component The name of the units associate with the field.
+/// \param [in] units The name of the units associate with the field.
+/// \memberof field_metadata
+void field_metadata_set_units(field_metadata_t* md, 
+                              int component, 
+                              const char* units);
+
+/// Returns true if the given component of the field for this metadata 
+/// represents a conserved quantity, false if not. 
+/// \param [in] component The component of the queried quantity.
+/// \memberof field_metadata
+bool field_metadata_conserved(field_metadata_t* md, int component);
+
+/// Sets a flag indicating whether the given component of the field for this
+/// metadata represents a conserved quantity.
+/// \param [in] component The name of the units associate with the field.
+/// \param [in] conserved Set to true for conserved quantities, false for others.
+/// \memberof field_metadata
+void field_metadata_set_conserved(field_metadata_t* md, 
+                                  int component,
+                                  bool conserved);
+
+/// Returns true if the given component of the field for this metadata 
+/// represents an extensive quantity in the sense that it scales with mass, 
+/// false if it is intensive.
+/// \param [in] component The component of the queried quantity.
+/// \memberof field_metadata
+bool field_metadata_extensive(field_metadata_t* md, int component);
+
+/// Sets a flag indicating whether the given component of the field for this
+/// metadata represents an extensive quantity in the sense that it scales with 
+/// mass, false if it is intensive.
+/// \param [in] component The name of the units associate with the field.
+/// \param [in] extensive Set to true for extensive quantities, false for 
+///                       intensive quantities.
+/// \memberof field_metadata
+void field_metadata_set_extensive(field_metadata_t* md, 
+                                  int component,
+                                  bool extensive);
+
+/// Returns true if the field for this metadata contains one or more vector-
+/// valued quantities, false if it contains none.
+/// \memberof field_metadata
+bool field_metadata_has_vectors(field_metadata_t* md);
+
+/// Loops over vector-valued quantities, retrieving the component at which 
+/// each vector-valued quantity begins.
+/// \param [inout] pos Controls the traversal. Set to 0 to reset.
+/// \param [out] comp Stores the component at which the vector quantity begins.
+///                   Each vector-valued quantity occupies 3 consecutive 
+///                   components.
+/// \returns true if the field has another vector quantity, false if the 
+///          loop has terminated.
+/// \memberof field_metadata
+bool field_metadata_next_vector(field_metadata_t* md,
+                                int* pos,
+                                int* comp);
+
+/// Returns true if the field for this metadata contains one or more rank 2 
+/// tensor2-valued quantities, false if it contains none.
+/// \memberof field_metadata
+bool field_metadata_has_tensor2s(field_metadata_t* md);
+
+/// Loops over rank 2 tensor-valued quantities, retrieving the component at 
+/// which each tensor-valued quantity begins.
+/// \param [inout] pos Controls the traversal. Set to 0 to reset.
+/// \param [out] comp Stores the component at which the rank 2 tensor quantity 
+///                   begins. Each such quantity occupies 9 consecutive 
+///                   components.
+/// \returns true if the field has another rank 2 tensor quantity, false if the 
+///          loop has terminated.
+/// \memberof field_metadata
+bool field_metadata_next_tensor2(field_metadata_t* md,
+                                 int* pos,
+                                 int* comp);
+
+/// Returns true if the field for this metadata contains one or more rank 2 
+/// symmetric tensor2-valued quantities, false if it contains none.
+/// \memberof field_metadata
+bool field_metadata_has_symtensor2s(field_metadata_t* md);
+
+/// Loops over rank 2 symmetric tensor-valued quantities, retrieving the 
+/// component at which each such quantity begins.
+/// \param [inout] pos Controls the traversal. Set to 0 to reset.
+/// \param [out] comp Stores the component at which the symmetric rank 2 
+///                   tensor quantity begins. Each such quantity occupies 6 
+///                   consecutive components.
+/// \returns true if the field has another symmetric rank 2 tensor quantity, 
+///          false if the loop has terminated.
+/// \memberof field_metadata
+bool field_metadata_next_symtensor2(field_metadata_t* md,
+                                    int* pos,
+                                    int* comp);
+
+///@}
+
+#endif

--- a/geometry/field_metadata.h
+++ b/geometry/field_metadata.h
@@ -91,6 +91,12 @@ void field_metadata_set_extensive(field_metadata_t* md,
                                   int component,
                                   bool extensive);
 
+/// Specifies that the given component in the field associated with this metadata is 
+/// the first component of a (3-component) vector.
+/// \param [in] component The component at which a vector-valued quantity begins.
+/// \memberof field_metadata
+void field_metadata_set_vector(field_metadata_t* md, int component);
+
 /// Returns true if the field for this metadata contains one or more vector-
 /// valued quantities, false if it contains none.
 /// \memberof field_metadata
@@ -109,6 +115,12 @@ bool field_metadata_next_vector(field_metadata_t* md,
                                 int* pos,
                                 int* comp);
 
+/// Specifies that the given component in the field associated with this metadata is 
+/// the first component of a (9-component) rank 2 tensor.
+/// \param [in] component The component at which a rank 2 tensor-valued quantity begins.
+/// \memberof field_metadata
+void field_metadata_set_tensor2(field_metadata_t* md, int component);
+
 /// Returns true if the field for this metadata contains one or more rank 2 
 /// tensor2-valued quantities, false if it contains none.
 /// \memberof field_metadata
@@ -126,6 +138,12 @@ bool field_metadata_has_tensor2s(field_metadata_t* md);
 bool field_metadata_next_tensor2(field_metadata_t* md,
                                  int* pos,
                                  int* comp);
+
+/// Specifies that the given component in the field associated with this metadata is 
+/// the first component of a (6-component) symmetric rank 2 tensor.
+/// \param [in] component The component at which a rank 2 symmetric tensor-valued quantity begins.
+/// \memberof field_metadata
+void field_metadata_set_symtensor2(field_metadata_t* md, int component);
 
 /// Returns true if the field for this metadata contains one or more rank 2 
 /// symmetric tensor2-valued quantities, false if it contains none.

--- a/geometry/point_cloud_field.c
+++ b/geometry/point_cloud_field.c
@@ -37,13 +37,21 @@ point_cloud_field_t* point_cloud_field_new(point_cloud_t* cloud,
   point_cloud_observer_t* obs = point_cloud_observer_new(field, obs_vtable);
   point_cloud_add_observer(cloud, obs);
 
+  field->md = field_metadata_new(num_components);
+
   return field;
 }
 
 void point_cloud_field_free(point_cloud_field_t* field)
 {
   polymec_free(field->data);
+  release_ref(field->md);
   polymec_free(field);
+}
+
+field_metadata_t* point_cloud_field_metadata(point_cloud_field_t* field)
+{
+  return field->md;
 }
 
 real_enumerable_generator_t* point_cloud_field_enumerate(point_cloud_field_t* field)

--- a/geometry/point_cloud_field.h
+++ b/geometry/point_cloud_field.h
@@ -9,6 +9,7 @@
 #define POLYMEC_POINT_CLOUD_FIELD_H
 
 #include "core/declare_nd_array.h"
+#include "geometry/field_metadata.h"
 #include "geometry/point_cloud.h"
 
 /// \addtogroup geometry geometry
@@ -35,6 +36,9 @@ typedef struct
   /// Data for the field, and its storage capacity.
   real_t* data;
   size_t capacity;
+
+  /// Metadata.
+  field_metadata_t* md;
 } point_cloud_field_t;
 
 /// Constructs a new point cloud field with the given number of components
@@ -46,6 +50,11 @@ point_cloud_field_t* point_cloud_field_new(point_cloud_t* cloud,
 /// Destroys the given point cloud field.
 /// \memberof point_cloud_field
 void point_cloud_field_free(point_cloud_field_t* field);
+
+/// Returns the metadata associated with this field. Every field has a 
+/// metadata object that is empty until its properties are specified.
+/// \memberof unimesh_field
+field_metadata_t* point_cloud_field_metadata(point_cloud_field_t* field);
 
 typedef struct real_enumerable_generator_t real_enumerable_generator_t;
 

--- a/geometry/polymesh_field.c
+++ b/geometry/polymesh_field.c
@@ -41,6 +41,8 @@ polymesh_field_t* polymesh_field_new(polymesh_t* mesh,
   field->capacity = field->num_local_values + field->num_ghost_values;
   field->data = polymec_calloc(sizeof(real_t) * num_components * field->capacity);
 
+  field->md = field_metadata_new(num_components);
+
   return field;
 }
 
@@ -49,7 +51,13 @@ void polymesh_field_free(polymesh_field_t* field)
   if (field->ex != NULL)
     release_ref(field->ex);
   polymec_free(field->data);
+  release_ref(field->md);
   polymec_free(field);
+}
+
+field_metadata_t* polymesh_field_metadata(polymesh_field_t* field)
+{
+  return field->md;
 }
 
 void polymesh_field_exchange(polymesh_field_t* field)

--- a/geometry/polymesh_field.h
+++ b/geometry/polymesh_field.h
@@ -9,6 +9,7 @@
 #define POLYMEC_POLYMESH_FIELD_H
 
 #include "core/declare_nd_array.h"
+#include "geometry/field_metadata.h"
 #include "geometry/polymesh.h"
 
 /// \addtogroup geometry geometry
@@ -43,6 +44,9 @@ typedef struct
   /// Parallel exchanger / token.
   exchanger_t* ex;
   int ex_token;
+
+  // Metadata.
+  field_metadata_t* md;
 } polymesh_field_t;
 
 /// Constructs a new polymesh field with the given number of components
@@ -55,6 +59,11 @@ polymesh_field_t* polymesh_field_new(polymesh_t* mesh,
 /// Destroys the given polymesh field.
 /// \memberof polymesh_field
 void polymesh_field_free(polymesh_field_t* field);
+
+/// Returns the metadata associated with this field. Every field has a 
+/// metadata object that is empty until its properties are specified.
+/// \memberof unimesh_field
+field_metadata_t* polymesh_field_metadata(polymesh_field_t* field);
 
 /// Synchronously exchanges boundary data in this field with that of 
 /// adjoining subdomains. For cell-centered data, this 

--- a/geometry/unimesh_field.h
+++ b/geometry/unimesh_field.h
@@ -8,6 +8,7 @@
 #ifndef POLYMEC_UNIMESH_FIELD_H
 #define POLYMEC_UNIMESH_FIELD_H
 
+#include "geometry/field_metadata.h"
 #include "geometry/unimesh_patch.h"
 
 /// \addtogroup geometry geometry
@@ -49,12 +50,17 @@ unimesh_field_t* unimesh_field_with_buffer(unimesh_t* mesh,
 /// \memberof unimesh_field
 void unimesh_field_free(unimesh_field_t* field);
 
-/// Copies all data in this field to the destination field.
+/// Copies all data and metadata in this field to the destination field.
 /// The destination object must share the same underlying mesh and 
 /// centering.
 /// \memberof unimesh_field
 void unimesh_field_copy(unimesh_field_t* field,
                         unimesh_field_t* dest);
+
+/// Returns the metadata associated with this field. Every field has a 
+/// metadata object that is empty until its properties are specified.
+/// \memberof unimesh_field
+field_metadata_t* unimesh_field_metadata(unimesh_field_t* field);
 
 /// Returns the centering of the unimesh_field.
 /// \memberof unimesh_field

--- a/io/silo_file.h
+++ b/io/silo_file.h
@@ -32,30 +32,6 @@
 /// compression.
 void silo_enable_compression(int level);
 
-/// \struct silo_field_metadata_t
-/// This type represents a collection of metadata for field variables in 
-/// Silo files. 
-/// \refcounted
-struct silo_field_metadata_t
-{
-  /// A visualization label. Owned by metadata.
-  char* label; 
-  /// Units of measure. Owned by metadata.
-  char* units; 
-  /// True if the field is conserved, false if not.
-  bool conserved; 
-  /// True if the field is extensive, false if not.
-  bool extensive; 
-  /// The index of the vector component that the field represents, or -1 if 
-  /// the field is not the component of a vector.
-  int vector_component; 
-};
-typedef struct silo_field_metadata_t silo_field_metadata_t;
-
-/// Creates a new empty object for storing field metadata.
-/// \memberof silo_field_metadata
-silo_field_metadata_t* silo_field_metadata_new(void);
-
 /// \class silo_file
 /// A Silo file stores various geometries (meshes) and data, using 
 /// "Poor Man's Parallel I/O" (PMPIO) to achieve scalable throughput.
@@ -154,20 +130,15 @@ void silo_file_write_unimesh_field(silo_file_t* file,
                                    const char** field_component_names,
                                    const char* mesh_name,
                                    unimesh_field_t* field,
-                                   silo_field_metadata_t** field_metadata,
                                    coord_mapping_t* mapping);
 
 /// Reads a uniform cartesian mesh field with the given component names from 
 /// the given Silo file if it is associated with the mesh with the given name. 
-/// If an non-NULL array of silo_field_metadata objects is passed as the last 
-/// argument, metadata for each field will be read into corresponding entries 
-/// there--otherwise it can be NULL.
 /// \memberof silo_file
 void silo_file_read_unimesh_field(silo_file_t* file, 
                                   const char** field_component_names,
                                   const char* mesh_name,
-                                  unimesh_field_t* field,
-                                  silo_field_metadata_t** field_metadata);
+                                  unimesh_field_t* field);
 
 /// Returns true if the Silo file contains a uniform cartesian mesh field
 /// (or component) with the given name, associated with mesh with the given 
@@ -215,20 +186,15 @@ void silo_file_write_colmesh_field(silo_file_t* file,
                                     const char** field_component_names,
                                     const char* mesh_name,
                                     colmesh_field_t* field,
-                                    silo_field_metadata_t** field_metadata,
                                     coord_mapping_t* mapping);
 
 /// Reads a prism mesh field with the given component names from 
 /// the given Silo file if it is associated with the mesh with the given name. 
-/// If an non-NULL array of silo_field_metadata objects is passed as the last 
-/// argument, metadata for each field will be read into corresponding entries 
-/// there--otherwise it can be NULL.
 /// \memberof silo_file
 void silo_file_read_colmesh_field(silo_file_t* file, 
-                                   const char** field_component_names,
-                                   const char* mesh_name,
-                                   colmesh_field_t* field,
-                                   silo_field_metadata_t** field_metadata);
+                                  const char** field_component_names,
+                                  const char* mesh_name,
+                                  colmesh_field_t* field);
 
 /// Returns true if the Silo file contains a prism mesh field component
 /// (or component) with the given name, associated with mesh with the given 
@@ -258,26 +224,20 @@ bool silo_file_contains_polymesh(silo_file_t* file, const char* mesh_name);
 
 /// Writes a named multicomponent field of the given centering on a polymesh, 
 /// understood to exist on the polymesh with the given name, to the given Silo 
-/// file. The field data is interpreted to be in component-minor order. If an 
-/// array of metadata objects is passed as the last argument, the metadata for 
-/// the field will also be written to the file--otherwise it can be NULL.
+/// file. The field data is interpreted to be in component-minor order. 
 /// \memberof silo_file
 void silo_file_write_polymesh_field(silo_file_t* file,
                                     const char** field_component_names,
                                     const char* mesh_name,
-                                    polymesh_field_t* field,
-                                    silo_field_metadata_t** field_metadata);
+                                    polymesh_field_t* field);
 
 /// Reads a named multicomponent field with the given polymesh centering from 
-/// the Silo file, returning a newly-allocated array of field data. If an array 
-/// of metadata objects is passed as the last argument, the metadata for the 
-/// field will be read into it--otherwise it can be NULL.
+/// the Silo file, returning a newly-allocated array of field data. 
 /// \memberof silo_file
 void silo_file_read_polymesh_field(silo_file_t* file,
                                    const char** field_component_names,
                                    const char* mesh_name,
-                                   polymesh_field_t* field,
-                                   silo_field_metadata_t** field_metadata);
+                                   polymesh_field_t* field);
 
 /// Returns true if the given Silo file contains a polymesh field component
 /// with the given centering and name, and associated with the given polymesh, 
@@ -323,25 +283,19 @@ bool silo_file_contains_point_cloud(silo_file_t* file, const char* cloud_name);
 
 /// Writes a named multicomponent point field to the given Silo file, 
 /// associated with the given point cloud. The field data is interpreted to 
-/// be in component-minor order. If an array of metadata objects is passed as 
-/// the last argument, the metadata for the field will also be written to the 
-/// file--otherwise it can be NULL.
+/// be in component-minor order.
 /// \memberof silo_file
 void silo_file_write_point_field(silo_file_t* file,
                                  const char** field_component_names,
                                  const char* cloud_name,
-                                 point_cloud_field_t* field,
-                                 silo_field_metadata_t** field_metadata);
+                                 point_cloud_field_t* field);
 
 /// Reads a named multicomponent point field from the Silo file.
-/// If an array of metadata objects is passed as the last argument, the 
-/// metadata for the field will be read into it--otherwise it can be NULL.
 /// \memberof silo_file
 void silo_file_read_point_field(silo_file_t* file,
                                 const char** field_component_names,
                                 const char* cloud_name,
-                                point_cloud_field_t* field,
-                                silo_field_metadata_t** field_metadata);
+                                point_cloud_field_t* field);
 
 /// Returns true if the given Silo file contains a (scalar) point field 
 /// with the given name and associated with the given cloud, false otherwise.

--- a/io/tests/test_create_rectilinear_polymesh_io.c
+++ b/io/tests/test_create_rectilinear_polymesh_io.c
@@ -32,13 +32,12 @@ static void test_plot_rectilinear_mesh(void** state)
   const char* cnames[] = {"solution"};
   for (int c = 0; c < mesh->num_cells; ++c)
     cvals[c][0] = 1.0*c;
-  silo_field_metadata_t* metadata = silo_field_metadata_new();
-  metadata->label = string_dup("solution");
-  metadata->units = string_dup("quatloo");
-  metadata->conserved = true;
-  metadata->extensive = false;
-  metadata->vector_component = 2;
-  silo_file_write_polymesh_field(silo, cnames, "mesh", cfield, &metadata);
+  field_metadata_t* c_md = polymesh_field_metadata(cfield);
+  field_metadata_set_name(c_md, 0, "solution");
+  field_metadata_set_units(c_md, 0, "quatloo");
+  field_metadata_set_conserved(c_md, 0, true);
+  field_metadata_set_extensive(c_md, 0, false);
+  silo_file_write_polymesh_field(silo, cnames, "mesh", cfield);
 
   // Add some fields with different centerings.
   polymesh_field_t* nfield = polymesh_field_new(mesh, POLYMESH_NODE, 3);
@@ -50,25 +49,24 @@ static void test_plot_rectilinear_mesh(void** state)
     nvals[n][1] = mesh->nodes[n].y;
     nvals[n][2] = mesh->nodes[n].z;
   }
-  silo_file_write_polymesh_field(silo, nnames, "mesh", nfield, NULL);
+  silo_file_write_polymesh_field(silo, nnames, "mesh", nfield);
   
   polymesh_field_t* ffield = polymesh_field_new(mesh, POLYMESH_FACE, 1);
   DECLARE_POLYMESH_FIELD_ARRAY(fvals, ffield);
   const char* fnames[] = {"fvals"};
   for (int f = 0; f < mesh->num_faces; ++f)
     fvals[f][0] = 1.0 * f;
-  silo_file_write_polymesh_field(silo, fnames, "mesh", ffield, NULL);
+  silo_file_write_polymesh_field(silo, fnames, "mesh", ffield);
 
   polymesh_field_t* efield = polymesh_field_new(mesh, POLYMESH_EDGE, 1);
   DECLARE_POLYMESH_FIELD_ARRAY(evals, efield);
   const char* enames[] = {"evals"};
   for (int e = 0; e < mesh->num_edges; ++e)
     evals[e][0] = 1.0 * e;
-  silo_file_write_polymesh_field(silo, enames, "mesh", efield, NULL);
+  silo_file_write_polymesh_field(silo, enames, "mesh", efield);
   silo_file_close(silo);
 
   // Now read the mesh from the file.
-  metadata = silo_field_metadata_new();
   real_t t;
   silo = silo_file_open(MPI_COMM_WORLD, "rectilinear_4x4x4", "", 0, &t);
   assert_true(reals_equal(t, 0.0));
@@ -81,25 +79,24 @@ static void test_plot_rectilinear_mesh(void** state)
   // cell field
   assert_true(silo_file_contains_polymesh_field(silo, "solution", "mesh", POLYMESH_CELL));
   polymesh_field_t* cfield1 = polymesh_field_new(mesh, POLYMESH_CELL, 1);
-  silo_file_read_polymesh_field(silo, cnames, "mesh", cfield1, &metadata);
+  silo_file_read_polymesh_field(silo, cnames, "mesh", cfield1);
   assert_true(ALL(compare_values(polymesh_field_enumerate(cfield1), 
                                  polymesh_field_enumerate(cfield), 
                                  reals_equal)));
 
   // cell field metadata
-  assert_int_equal(0, strcmp(metadata->label, "solution"));
-  assert_int_equal(0, strcmp(metadata->units, "quatloo"));
-  assert_true(metadata->conserved);
-  assert_false(metadata->extensive);
-  assert_int_equal(2, metadata->vector_component);
-  release_ref(metadata);
+  field_metadata_t* c1_md = polymesh_field_metadata(cfield1);
+  assert_int_equal(0, strcmp(field_metadata_name(c1_md, 0), "solution"));
+  assert_int_equal(0, strcmp(field_metadata_units(c1_md, 0), "quatloo"));
+  assert_true(field_metadata_conserved(c1_md, 0));
+  assert_false(field_metadata_extensive(c1_md, 0));
 
   // node field
   assert_true(silo_file_contains_polymesh_field(silo, "nx", "mesh", POLYMESH_NODE));
   assert_true(silo_file_contains_polymesh_field(silo, "ny", "mesh", POLYMESH_NODE));
   assert_true(silo_file_contains_polymesh_field(silo, "nz", "mesh", POLYMESH_NODE));
   polymesh_field_t* nfield1 = polymesh_field_new(mesh, POLYMESH_NODE, 3);
-  silo_file_read_polymesh_field(silo, nnames, "mesh", nfield1, NULL);
+  silo_file_read_polymesh_field(silo, nnames, "mesh", nfield1);
   assert_true(ALL(compare_values(polymesh_field_enumerate(nfield1), 
                                  polymesh_field_enumerate(nfield), 
                                  reals_equal)));
@@ -107,7 +104,7 @@ static void test_plot_rectilinear_mesh(void** state)
   // face field
   assert_true(silo_file_contains_polymesh_field(silo, "fvals", "mesh", POLYMESH_FACE));
   polymesh_field_t* ffield1 = polymesh_field_new(mesh, POLYMESH_FACE, 1);
-  silo_file_read_polymesh_field(silo, fnames, "mesh", ffield1, NULL);
+  silo_file_read_polymesh_field(silo, fnames, "mesh", ffield1);
   assert_true(ALL(compare_values(polymesh_field_enumerate(ffield1), 
                                  polymesh_field_enumerate(ffield), 
                                  reals_equal)));
@@ -115,7 +112,7 @@ static void test_plot_rectilinear_mesh(void** state)
   // edge field
   assert_true(silo_file_contains_polymesh_field(silo, "evals", "mesh", POLYMESH_EDGE));
   polymesh_field_t* efield1 = polymesh_field_new(mesh, POLYMESH_EDGE, 1);
-  silo_file_read_polymesh_field(silo, enames, "mesh", efield1, NULL);
+  silo_file_read_polymesh_field(silo, enames, "mesh", efield1);
   assert_true(ALL(compare_values(polymesh_field_enumerate(efield1), 
                                  polymesh_field_enumerate(efield), 
                                  reals_equal)));

--- a/io/tests/test_create_uniform_polymesh_io.c
+++ b/io/tests/test_create_uniform_polymesh_io.c
@@ -31,7 +31,7 @@ static void test_plot_uniform_mesh_with_num_files(void** state, int num_files)
   const char* cnames[] = {"solution"};
   for (int c = 0; c < 4*4*4; ++c)
     cvals[c][0] = 1.0*c;
-  silo_file_write_polymesh_field(silo, cnames, "mesh", cfield, NULL);
+  silo_file_write_polymesh_field(silo, cnames, "mesh", cfield);
   silo_file_close(silo);
 
   // Query the plot file to make sure its numbers are good.

--- a/io/tests/test_crop_polymesh_io.c
+++ b/io/tests/test_crop_polymesh_io.c
@@ -68,7 +68,7 @@ static void test_cylindrical_crop(void** state)
   for (int c = 0; c < cropped_mesh->num_cells; ++c)
     data[c][0] = 1.0*c;
   const char* ones_name[] = {"ones"};
-  silo_file_write_polymesh_field(silo, ones_name, "mesh", ones, NULL);
+  silo_file_write_polymesh_field(silo, ones_name, "mesh", ones);
   silo_file_close(silo);
 
   polymesh_field_free(ones);
@@ -97,7 +97,7 @@ static void test_spherical_crop(void** state)
   for (int c = 0; c < cropped_mesh->num_cells; ++c)
     data[c][0] = 1.0*c;
   const char* ones_name[] = {"ones"};
-  silo_file_write_polymesh_field(silo, ones_name, "mesh", ones, NULL);
+  silo_file_write_polymesh_field(silo, ones_name, "mesh", ones);
   silo_file_close(silo);
 
   polymesh_field_free(ones);

--- a/io/tests/test_partition_point_cloud_io.c
+++ b/io/tests/test_partition_point_cloud_io.c
@@ -57,18 +57,16 @@ static void test_partition_linear_cloud(void** state)
   snprintf(filename, FILENAME_MAX, "linear_cloud_partition_%d", N);
   silo_file_t* silo = silo_file_new(comm, filename, filename, 1, 0, 0.0);
   silo_file_write_point_cloud(silo, "cloud", cloud);
-  silo_field_metadata_t* metadata = silo_field_metadata_new();
-  metadata->label = string_dup("rank");
-  metadata->units = string_dup("quatloo");
-  metadata->conserved = true;
-  metadata->extensive = false;
-  metadata->vector_component = 2;
+  field_metadata_t* p_md = point_cloud_field_metadata(p);
+  field_metadata_set_name(p_md, 0, "rank");
+  field_metadata_set_units(p_md, 0, "quatloo");
+  field_metadata_set_conserved(p_md, 0, true);
+  field_metadata_set_extensive(p_md, 0, false);
   const char* field_names[] = {"rank"};
-  silo_file_write_point_field(silo, field_names, "cloud", p, &metadata);
+  silo_file_write_point_field(silo, field_names, "cloud", p);
   silo_file_close(silo);
 
   // Now read the cloud from the file and make sure it's intact.
-  metadata = silo_field_metadata_new();
   real_t t;
   silo = silo_file_open(MPI_COMM_WORLD, filename, filename, 0, &t);
   assert_true(reals_equal(t, 0.0));
@@ -77,17 +75,15 @@ static void test_partition_linear_cloud(void** state)
   assert_true(cloud1->num_points == cloud->num_points);
   assert_true(silo_file_contains_point_field(silo, "rank", "cloud"));
   point_cloud_field_t* p1 = point_cloud_field_new(cloud1, 1);
-  silo_file_read_point_field(silo, field_names, "cloud", p1, &metadata);
+  silo_file_read_point_field(silo, field_names, "cloud", p1);
   assert_true(ANY(compare_values(point_cloud_field_enumerate(p1),
                                  point_cloud_field_enumerate(p),
                                  reals_equal)));
-
-  assert_int_equal(0, strcmp(metadata->label, "rank"));
-  assert_int_equal(0, strcmp(metadata->units, "quatloo"));
-  assert_true(metadata->conserved);
-  assert_false(metadata->extensive);
-  assert_int_equal(2, metadata->vector_component);
-  metadata = NULL;
+  field_metadata_t* p1_md = point_cloud_field_metadata(p1);
+  assert_int_equal(0, strcmp(field_metadata_name(p1_md, 0), "rank"));
+  assert_int_equal(0, strcmp(field_metadata_units(p1_md, 0), "quatloo"));
+  assert_true(field_metadata_conserved(p1_md, 0));
+  assert_false(field_metadata_extensive(p1_md, 0));
   silo_file_close(silo);
 
   // Clean up.
@@ -129,7 +125,7 @@ static void test_partition_planar_cloud(void** state)
   DECLARE_POINT_CLOUD_FIELD_ARRAY(p_data, p);
   for (int i = 0; i < cloud->num_points; ++i)
     p_data[i][0] = 1.0*rank;
-  silo_file_write_point_field(silo, field_names, "cloud", p, NULL);
+  silo_file_write_point_field(silo, field_names, "cloud", p);
   silo_file_close(silo);
 
   // Clean up.
@@ -174,7 +170,7 @@ static void test_partition_cubic_cloud(void** state)
   DECLARE_POINT_CLOUD_FIELD_ARRAY(p_data, p);
   for (int i = 0; i < cloud->num_points; ++i)
     p_data[i][0] = 1.0*rank;
-  silo_file_write_point_field(silo, field_names, "cloud", p, NULL);
+  silo_file_write_point_field(silo, field_names, "cloud", p);
   silo_file_close(silo);
 
   // Clean up.

--- a/io/tests/test_partition_polymesh_io.c
+++ b/io/tests/test_partition_polymesh_io.c
@@ -89,11 +89,11 @@ static void test_partition_linear_mesh(void** state)
   DECLARE_POLYMESH_FIELD_ARRAY(r, rfield);
   for (int c = 0; c < mesh->num_cells; ++c)
     r[c][0] = 1.0*rank;
-  silo_field_metadata_t* r_metadata = silo_field_metadata_new();
-  r_metadata->label = string_dup("P");
-  r_metadata->conserved = true;
+  field_metadata_t* r_metadata = polymesh_field_metadata(rfield);
+  field_metadata_set_name(r_metadata, 0, "P");
+  field_metadata_set_conserved(r_metadata, 0, true);
   const char* rname[] = {"rank"};
-  silo_file_write_polymesh_field(silo, rname, "mesh", rfield, &r_metadata);
+  silo_file_write_polymesh_field(silo, rname, "mesh", rfield);
   silo_file_close(silo);
 
   // Clean up.
@@ -156,7 +156,7 @@ static void test_partition_slab_mesh(void** state)
   for (int c = 0; c < mesh->num_cells; ++c)
     r[c][0] = 1.0*rank;
   const char* rname[] = {"rank"};
-  silo_file_write_polymesh_field(silo, rname, "mesh", rfield, NULL);
+  silo_file_write_polymesh_field(silo, rname, "mesh", rfield);
   silo_file_close(silo);
 
   // Clean up.
@@ -219,7 +219,7 @@ static void test_partition_box_mesh(void** state)
   for (int c = 0; c < mesh->num_cells; ++c)
     r[c][0] = 1.0*rank;
   const char* rname[] = {"rank"};
-  silo_file_write_polymesh_field(silo, rname, "mesh", rfield, NULL);
+  silo_file_write_polymesh_field(silo, rname, "mesh", rfield);
   silo_file_close(silo);
 
   // Clean up.

--- a/io/tests/test_repartition_point_cloud_io.c
+++ b/io/tests/test_repartition_point_cloud_io.c
@@ -162,7 +162,7 @@ static void test_repartition_linear_cloud(void** state,
   const char* pname[] = {"rank"};
   for (int i = 0; i < cloud->num_points; ++i)
     p[i][0] = 1.0*rank;
-  silo_file_write_point_field(silo, pname, "cloud", pfield, NULL);
+  silo_file_write_point_field(silo, pname, "cloud", pfield);
   silo_file_close(silo);
 
   // Clean up.

--- a/io/tests/test_repartition_polymesh_io.c
+++ b/io/tests/test_repartition_polymesh_io.c
@@ -204,7 +204,7 @@ static void test_repartition_uniform_mesh_of_size(void** state, int nx, int ny, 
   for (int c = 0; c < mesh->num_cells; ++c)
     r[c][0] = 1.0*rank;
   const char* rname[] = {"rank"};
-  silo_file_write_polymesh_field(silo, rname, "mesh", rfield, NULL);
+  silo_file_write_polymesh_field(silo, rname, "mesh", rfield);
   silo_file_close(silo);
 
   // Clean up.

--- a/io/tests/test_silo_file_unimesh_methods.c
+++ b/io/tests/test_silo_file_unimesh_methods.c
@@ -86,7 +86,7 @@ static void test_write_unimesh_cell_field(void** state)
   silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "test_silo_file_unimesh_methods", "test_write_unimesh_cell_field", 1, 0, 0.0);
   silo_file_write_unimesh(silo, "mesh", mesh, NULL);
   const char* field_names[4] = {"f1", "f2", "f3", "f4"};
-  silo_file_write_unimesh_field(silo, field_names, "mesh", field, NULL, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", field, NULL);
   silo_file_close(silo);
   unimesh_field_free(field);
   unimesh_free(mesh); 
@@ -101,7 +101,7 @@ static void test_write_unimesh_cell_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_CELL));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_CELL));
   field = unimesh_field_new(mesh, UNIMESH_CELL, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", field);
   pos = 0;
   while (unimesh_field_next_patch(field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -172,9 +172,9 @@ static void test_write_unimesh_face_field(void** state)
   silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "test_silo_file_unimesh_methods", "test_write_unimesh_face_field", 1, 0, 0.0);
   silo_file_write_unimesh(silo, "mesh", mesh, NULL);
   const char* field_names[4] = {"f1", "f2", "f3", "f4"};
-  silo_file_write_unimesh_field(silo, field_names, "mesh", x_field, NULL, NULL);
-  silo_file_write_unimesh_field(silo, field_names, "mesh", y_field, NULL, NULL);
-  silo_file_write_unimesh_field(silo, field_names, "mesh", z_field, NULL, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", x_field, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", y_field, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", z_field, NULL);
   silo_file_close(silo);
   unimesh_field_free(x_field);
   unimesh_field_free(y_field);
@@ -192,7 +192,7 @@ static void test_write_unimesh_face_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_XFACE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_XFACE));
   x_field = unimesh_field_new(mesh, UNIMESH_XFACE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", x_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", x_field);
   pos = 0;
   while (unimesh_field_next_patch(x_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -209,7 +209,7 @@ static void test_write_unimesh_face_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_YFACE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_YFACE));
   y_field = unimesh_field_new(mesh, UNIMESH_YFACE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", y_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", y_field);
   pos = 0;
   while (unimesh_field_next_patch(y_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -226,7 +226,7 @@ static void test_write_unimesh_face_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_ZFACE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_ZFACE));
   z_field = unimesh_field_new(mesh, UNIMESH_ZFACE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", z_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", z_field);
   pos = 0;
   while (unimesh_field_next_patch(z_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -299,9 +299,9 @@ static void test_write_unimesh_edge_field(void** state)
   silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "test_silo_file_unimesh_methods", "test_write_unimesh_edge_field", 1, 0, 0.0);
   silo_file_write_unimesh(silo, "mesh", mesh, NULL);
   const char* field_names[4] = {"f1", "f2", "f3", "f4"};
-  silo_file_write_unimesh_field(silo, field_names, "mesh", x_field, NULL, NULL);
-  silo_file_write_unimesh_field(silo, field_names, "mesh", y_field, NULL, NULL);
-  silo_file_write_unimesh_field(silo, field_names, "mesh", z_field, NULL, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", x_field, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", y_field, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", z_field, NULL);
   silo_file_close(silo);
   unimesh_field_free(x_field);
   unimesh_field_free(y_field);
@@ -319,7 +319,7 @@ static void test_write_unimesh_edge_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_XEDGE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_XEDGE));
   x_field = unimesh_field_new(mesh, UNIMESH_XEDGE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", x_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", x_field);
   pos = 0;
   while (unimesh_field_next_patch(x_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -336,7 +336,7 @@ static void test_write_unimesh_edge_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_YEDGE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_YEDGE));
   y_field = unimesh_field_new(mesh, UNIMESH_YEDGE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", y_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", y_field);
   pos = 0;
   while (unimesh_field_next_patch(y_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -353,7 +353,7 @@ static void test_write_unimesh_edge_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_ZEDGE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_ZEDGE));
   z_field = unimesh_field_new(mesh, UNIMESH_ZEDGE, 4);
-  silo_file_read_unimesh_field(silo, field_names, "mesh", z_field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", z_field);
   pos = 0;
   while (unimesh_field_next_patch(z_field, &pos, &I, &J, &K, &patch, NULL))
   {
@@ -402,7 +402,7 @@ static void test_write_unimesh_node_field(void** state)
   silo_file_t* silo = silo_file_new(MPI_COMM_WORLD, "test_silo_file_unimesh_methods", "test_write_unimesh_node_field", 1, 0, 0.0);
   silo_file_write_unimesh(silo, "mesh", mesh, NULL);
   const char* field_names[4] = {"f1", "f2", "f3", "f4"};
-  silo_file_write_unimesh_field(silo, field_names, "mesh", field, NULL, NULL);
+  silo_file_write_unimesh_field(silo, field_names, "mesh", field, NULL);
   silo_file_close(silo);
   unimesh_field_free(field);
   unimesh_free(mesh); 
@@ -417,7 +417,7 @@ static void test_write_unimesh_node_field(void** state)
   assert_true(silo_file_contains_unimesh_field(silo, "f2", "mesh", UNIMESH_NODE));
   assert_true(silo_file_contains_unimesh_field(silo, "f3", "mesh", UNIMESH_NODE));
   assert_true(silo_file_contains_unimesh_field(silo, "f4", "mesh", UNIMESH_NODE));
-  silo_file_read_unimesh_field(silo, field_names, "mesh", field, NULL);
+  silo_file_read_unimesh_field(silo, field_names, "mesh", field);
   pos = 0;
   while (unimesh_field_next_patch(field, &pos, &I, &J, &K, &patch, NULL))
   {


### PR DESCRIPTION
Added the field_metadata type for storing field metadata. All fields now come with empty field_metadata objects ready to be used. Replaced the Silo-specific mechanism for storing metadata with the new one.

Also: renamed sym_tensor2 type to symtensor2.